### PR TITLE
Allow select_prompt config to be a string or a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,16 @@ require('legendary').setup({
   -- Include builtins by default, set to false to disable
   include_builtin = true,
   -- Customize the prompt that appears on your vim.ui.select() handler
-  select_prompt = 'Legendary',
+  -- Can be a string or a function that takes the `kind` and returns
+  -- a string. See "Item Kinds" below for details.
+  select_prompt = function(kind)
+    if kind == 'legendary.items' then
+      return 'Legendary'
+    end
+
+    -- Convert kind to Title Case (e.g. legendary.keymaps => Legendary Keymaps)
+    return string.gsub(' ' .. kind:gsub('%.', ' '), '%W%l', string.upper):sub(2)
+  end,
   -- Initial keymaps to bind
   keymaps = {
     -- your keymap tables here
@@ -418,14 +427,11 @@ The following commands are available once `legendary.nvim` is loaded:
 
 Any `return` value from evaluated Lua is printed to the command area.
 
-### Sorting
+### Item Kinds
 
-`legendary.nvim` will set `kind` to `legendary.keymaps`, `legendary.commands`, `legendary.autocmds`,
-or `legendary-items`, depending on whether you are searching keymaps, commands, autocmds, or all.
-
-You can use to override the sorter used for `legendary.nvim` in your `vim.ui.select()`
-handler (for example, [dressing.nvim](https://github.com/stevearc/dressing.nvim) has a
-`get_config` option to do this).
+`legendary.nvim` will set the `kind` option on `vim.ui.select()` to `legendary.keymaps`,
+`legendary.commands`, `legendary.autocmds`, or `legendary-items`, depending on whether you
+are searching keymaps, commands, autocmds, or all.
 
 The individual items will have `kind = 'legendary.keymap'`, `kind = 'legendary.command'`,
 or `kind = 'legendary.autocmd'`, depending on whether it is a keymap, command, or autocmd.

--- a/lua/legendary/bindings.lua
+++ b/lua/legendary/bindings.lua
@@ -167,8 +167,8 @@ end
 --- with legendary.nvim. To find only keymaps, pass
 --- "keymaps" as a parameter, pass "commands" to find
 --- only commands, pass "autocmds" to find only autocmds.
----@param type string
-function M.find(type)
+---@param item_type string
+function M.find(item_type)
   local current_mode = vim.fn.mode()
   local visual_selection = nil
   if current_mode and current_mode:sub(1, 1):lower() == 'v' then
@@ -178,20 +178,26 @@ function M.find(type)
   local cursor_position = vim.api.nvim_win_get_cursor(0)
   local current_window_num = vim.api.nvim_win_get_number(0)
   local items
-  if type == 'keymaps' then
+  if item_type == 'keymaps' then
     items = keymaps
-  elseif type == 'commands' then
+  elseif item_type == 'commands' then
     items = commands
-  elseif type == 'autocmds' then
+  elseif item_type == 'autocmds' then
     items = autocmds
   else
     local concat = require('legendary.utils').concat_lists
     items = concat(concat(keymaps, commands), autocmds)
   end
 
+  local select_kind = string.format('legendary.%s', item_type or 'items')
+  local prompt = require('legendary.config').select_prompt
+  if type(prompt) == 'function' then
+    prompt = prompt(select_kind)
+  end
+
   vim.ui.select(items, {
-    prompt = require('legendary.config').select_prompt,
-    kind = string.format('legendary.%s', type or 'items'),
+    prompt = prompt,
+    kind = select_kind,
   }, function(selected)
     -- vim.schedule so that the select UI closes before we do anything
     vim.schedule(function()

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -1,7 +1,14 @@
 ---@type LegendaryConfig
 local M = {
   include_builtin = true,
-  select_prompt = 'Legendary',
+  select_prompt = function(kind)
+    if kind == 'legendary.items' then
+      return 'Legendary'
+    end
+
+    -- Convert kind to Title Case (e.g. legendary.keymaps => Legendary Keymaps)
+    return string.gsub(' ' .. kind:gsub('%.', ' '), '%W%l', string.upper):sub(2)
+  end,
   keymaps = {},
   commands = {},
   autocmds = {},


### PR DESCRIPTION
Fixes: #52 

Also sets up a default function defined as such:

```lua
function(kind)
  if kind == 'legendary.items' then
    return 'Legendary'
  end

  -- Convert kind to Title Case (e.g. legendary.keymaps => Legendary Keymaps)
  return string.gsub(' ' .. kind:gsub('%.', ' '), '%W%l', string.upper):sub(2)
end