### PR TITLE
implement lazy-loading items via autocmds, directly in table API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Define your keymaps, commands, and autocommands as simple Lua tables, building a
 - Uses `vim.ui.select()` so it can be hooked up to a fuzzy finder using something like [dressing.nvim](https://github.com/stevearc/dressing.nvim) for a VS Code command palette like interface
 - Execute normal, insert, and visual mode keymaps, commands, and autocommands, when you select them
 - Show your most recently executed keymap, command, or autocmd at the top when triggered via `legendary.nvim` (can be disabled via config)
+- Lazy-load keymaps, commands, and `autocmd`s on `autocmd` events
 - Buffer-local keymaps, commands, and autocmds only appear in the finder for the current buffer
 - Help execute commands that take arguments by prefilling the command line instead of executing immediately
 - Search built-in keymaps and commands along with your user-defined keymaps and commands (may be disabled in config). Notice some missing? Comment on [this discussion](https://github.com/mrjones2014/legendary.nvim/discussions/89) or submit a PR!
@@ -155,6 +156,38 @@ require('legendary').setup({
 require('legendary').setup({ auto_register_which_key = false })
 require('which-key').register(your_which_key_tables, your_which_key_opts)
 require('legendary').bind_whichkey(your_which_key_tables, your_which_key_opts)
+```
+
+## Lazy Loading
+
+You can lazy-load keymaps, commands, and `autocmd`s by including the `lazy` option
+in the `opts` table. The `lazy` option is a table with the following keys, describing
+the `autocmd` on which to bind the item:
+
+| key       | type                             | required            | example values                            |
+| --------- | -------------------------------- | ------------------- | ----------------------------------------- |
+| `event`   | `string` or `table` of `string`s | Yes                 | `BufEnter`, `{ 'BufRead', 'BufNewFile' }` |
+| `pattern` | `string` or `table` of `string`s | No, defaults to `*` | `json`, `{ 'json', 'jsonc' }`             |
+
+Example:
+
+```lua
+require('legendary').bind_keymap({
+  '<leader>oi',
+  require('ls-utils').organize_imports,
+  description = 'Organize imports',
+  opts = {
+    lazy = {
+      event = 'FileType',
+      pattern = {
+        'javascript',
+        'typescript',
+        'javascriptreact',
+        'typescriptreact',
+      }
+    }
+  }
+})
 ```
 
 ## Table Structures

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ require('legendary').bind_whichkey(your_which_key_tables, your_which_key_opts)
 ## Lazy Loading
 
 You can lazy-load keymaps, commands, and `autocmd`s by including the `lazy` option
-in the `opts` table. The `lazy` option is a table with the following keys, describing
+on the table. The `lazy` option is a table with the following keys, describing
 the `autocmd` on which to bind the item:
 
 | key       | type                             | required            | example values                            |
@@ -176,15 +176,13 @@ require('legendary').bind_keymap({
   '<leader>oi',
   require('ls-utils').organize_imports,
   description = 'Organize imports',
-  opts = {
-    lazy = {
-      event = 'FileType',
-      pattern = {
-        'javascript',
-        'typescript',
-        'javascriptreact',
-        'typescriptreact',
-      }
+  lazy = {
+    event = 'FileType',
+    pattern = {
+      'javascript',
+      'typescript',
+      'javascriptreact',
+      'typescriptreact',
     }
   }
 })

--- a/lua/legendary/bindings.lua
+++ b/lua/legendary/bindings.lua
@@ -34,9 +34,13 @@ function M.bind_keymap(keymap, kind)
     keymap.opts.buffer = vim.api.nvim_get_current_buf()
   end
 
-  require('legendary.utils').set_keymap(keymap)
-  require('legendary.formatter').update_padding(keymap)
-  table.insert(keymaps, keymap)
+  if keymap.lazy then
+    require('legendary.utils').setup_lazy_load(keymap)
+  else
+    require('legendary.utils').set_keymap(keymap)
+    require('legendary.formatter').update_padding(keymap)
+    table.insert(keymaps, keymap)
+  end
 end
 
 --- Bind a list of keymaps with legendary.nvim
@@ -77,9 +81,13 @@ function M.bind_command(cmd, kind)
     return
   end
 
-  require('legendary.utils').set_command(cmd)
-  require('legendary.formatter').update_padding(cmd)
-  table.insert(commands, cmd)
+  if cmd.lazy then
+    require('legendary.utils').setup_lazy_load(cmd)
+  else
+    require('legendary.utils').set_command(cmd)
+    require('legendary.formatter').update_padding(cmd)
+    table.insert(commands, cmd)
+  end
 end
 
 --- Bind a list of commands with legendary.nvim
@@ -129,10 +137,14 @@ local function bind_autocmd(autocmd, group, kind)
     autocmd.opts.buffer = vim.api.nvim_get_current_buf()
   end
 
-  require('legendary.utils').set_autocmd(autocmd, group)
-  if autocmd.description and #autocmd.description > 0 and not (autocmd.opts or {}).once then
-    require('legendary.formatter').update_padding(autocmd)
-    table.insert(autocmds, autocmd)
+  if autocmd.lazy then
+    require('legendary.utils').setup_lazy_load(autocmd, group)
+  else
+    require('legendary.utils').set_autocmd(autocmd, group)
+    if autocmd.description and #autocmd.description > 0 and not (autocmd.opts or {}).once then
+      require('legendary.formatter').update_padding(autocmd)
+      table.insert(autocmds, autocmd)
+    end
   end
 end
 

--- a/lua/legendary/bindings.lua
+++ b/lua/legendary/bindings.lua
@@ -15,8 +15,9 @@ local autocmds = require('legendary.config').autocmds
 local formatter = require('legendary.formatter')
 
 --- Bind a single keymap with legendary.nvim
----@param keymap LegendaryItem
-function M.bind_keymap(keymap, kind)
+---@param keymap_input LegendaryItem
+function M.bind_keymap(keymap_input, kind)
+  local keymap = vim.deepcopy(keymap_input)
   keymap.kind = kind or 'legendary.keymap'
   keymap.id = next_id()
   require('legendary.types').LegendaryItem.validate(keymap)
@@ -26,12 +27,12 @@ function M.bind_keymap(keymap, kind)
     return
   end
 
-  if require('legendary.utils').list_contains(keymaps, keymap) then
-    return
-  end
-
   if keymap.opts and keymap.opts.buffer == 0 then
     keymap.opts.buffer = vim.api.nvim_get_current_buf()
+  end
+
+  if require('legendary.utils').list_contains(keymaps, keymap) then
+    return
   end
 
   if keymap.lazy then
@@ -63,8 +64,9 @@ function M.bind_keymaps(new_keymaps, kind)
 end
 
 --- Bind a single command with legendary.nvim
----@param cmd LegendaryItem
-function M.bind_command(cmd, kind)
+---@param cmd_input LegendaryItem
+function M.bind_command(cmd_input, kind)
+  local cmd = vim.deepcopy(cmd_input)
   cmd.kind = kind or 'legendary.command'
   cmd.id = next_id()
   require('legendary.types').LegendaryItem.validate(cmd)
@@ -110,8 +112,9 @@ function M.bind_commands(cmds, kind)
 end
 
 --- Bind a single autocmd with legendary.nvim
----@param autocmd LegendaryItem
-local function bind_autocmd(autocmd, group, kind)
+---@param autocmd_input LegendaryItem
+local function bind_autocmd(autocmd_input, group, kind)
+  local autocmd = vim.deepcopy(autocmd_input)
   autocmd.kind = kind or 'legendary.autocmd'
   autocmd.id = next_id()
   require('legendary.types').LegendaryItem.validate(autocmd)
@@ -129,12 +132,12 @@ local function bind_autocmd(autocmd, group, kind)
     return
   end
 
-  if require('legendary.utils').list_contains(autocmds, autocmd) then
-    return
-  end
-
   if autocmd.opts and autocmd.opts.buffer == 0 then
     autocmd.opts.buffer = vim.api.nvim_get_current_buf()
+  end
+
+  if require('legendary.utils').list_contains(autocmds, autocmd) then
+    return
   end
 
   if autocmd.lazy then

--- a/lua/legendary/types.lua
+++ b/lua/legendary/types.lua
@@ -32,6 +32,7 @@ M.LegendaryConfig = {
 ---@field opts table
 ---@field kind string
 ---@field id number
+---@field lazy nil | LegendaryLazy
 M.LegendaryItem = {
   validate = function(item)
     -- diagnostics see vim.validate() as not accepting any parameters for some reason
@@ -44,6 +45,21 @@ M.LegendaryItem = {
       opts = { item.opts, 'table', true },
       kind = { item.kind, 'string' },
       id = { item.id, 'number' },
+    })
+  end,
+}
+
+---@class LegendaryLazy
+---@field event string | table
+---@field pattern string | table | nil
+M.LegendaryLazy = {
+  validate = function(lazy)
+    -- diagnostics see vim.validate() as not accepting any parameters for some reason
+    ---@diagnostic disable-next-line: redundant-parameter
+    vim.validate({
+      lazy = { lazy, 'table' },
+      lazy_event = { lazy.event, { 'string', 'table' } },
+      lazy_pattern = { lazy.pattern, { 'string', 'table' }, true },
     })
   end,
 }

--- a/lua/legendary/utils.lua
+++ b/lua/legendary/utils.lua
@@ -47,25 +47,20 @@ function M.setup_lazy_load(item, group)
   types.LegendaryItem.validate(item)
   types.LegendaryLazy.validate(item.lazy)
   require('legendary').bind_autocmds({
-    name = 'LegendaryItemLazyLoad',
-    clear = false,
-    {
-      item.lazy.event,
-      function()
-        item.lazy = nil
-        if vim.startswith(item.kind, 'legendary.keymap') then
-          require('legendary').bind_keymap(item)
-        elseif vim.startswith(item.kind, 'legendary.command') then
-          require('legendary').bind_command(item)
-        elseif vim.startswith(item.kind, 'legendary.autocmd') then
-          require('legendary').bind_autocmd(item, group)
-        end
-      end,
-      opts = {
-        pattern = item.lazy.pattern,
-        once = true,
-        description = 'find me',
-      },
+    item.lazy.event,
+    function()
+      item.lazy = nil
+      if vim.startswith(item.kind, 'legendary.keymap') then
+        require('legendary').bind_keymap(item)
+      elseif vim.startswith(item.kind, 'legendary.command') then
+        require('legendary').bind_command(item)
+      elseif vim.startswith(item.kind, 'legendary.autocmd') then
+        require('legendary').bind_autocmd(item, group)
+      end
+    end,
+    opts = {
+      pattern = item.lazy.pattern,
+      once = true,
     },
   })
 end


### PR DESCRIPTION
Resolves: #99 

## How to Test

1. Add the following keymap to your `init.lua`:
```lua
require('legendary').bind_keymap({
  '<leader>p',
  require('legendary').find,
  description = 'Find keymaps, commands, and autocmds',
  lazy = {
    event = 'FileType',
    pattern = 'lua', 
  },
})
```
2. Close Neovim
3. Reopen Neovim with no arguments (do not open a file, just open Neovim)
4. Press `<leader>p` - it should not do anything
5. Open a Lua file - `<leader>p` should now open the Legendary finder

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
