### PR TITLE
Allow separate opts tables to be passed per-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,24 @@ local keymaps = {
 }
 ```
 
+If you need to pass separate opts per-mode, you can do that too:
+
+```lua
+local keymaps = {
+  {
+    '<leader>c',
+    {
+      n = { ':CommentToggle<CR>' opts = { noremap = true } },
+      v = {':SomethingElseInVisualMode<CR>' opts = { silent = false } }
+    },
+    description = 'Toggle comment'
+    -- if outer opts exist, the inner opts tables will be merged,
+    -- with the inner opts taking precedence
+    opts = { expr = false }
+  }
+}
+```
+
 You can also pass options to the keymap via the `opts` property, see `:h vim.keymap.set` to
 see available options.
 


### PR DESCRIPTION
Resolves: #105  <!-- If this PR fixes an open issue, please link it here -->

## How to Test

1. Create a set of mappings that require different opts in different modes using the syntax described in the README.md changes of this PR 
1. Ensure the opts correctly apply in each mode

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
