### PR TITLE
Add option to allow which-key to handle bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,11 @@ require('legendary').setup({
     -- or alternatively have them auto-register,
     -- see section on which-key integration
     mappings = {},
-    opts = {}
+    opts = {},
+    -- whether or not to actually *bind* the keymaps,
+    -- true by default, set to false if you want to have
+    -- which-key.nvim handle binding them
+    do_binding = true,
   },
   -- Automatically add which-key tables to legendary
   -- see "which-key.nvim Integration" below for more details

--- a/lua/legendary/bindings.lua
+++ b/lua/legendary/bindings.lua
@@ -16,7 +16,7 @@ local formatter = require('legendary.formatter')
 
 --- Bind a single keymap with legendary.nvim
 ---@param keymap LegendaryItem
-function M.bind_keymap(keymap, kind)
+function M.bind_keymap(keymap, kind, is_which_key)
   keymap.kind = kind or 'legendary.keymap'
   keymap.id = next_id()
   require('legendary.types').LegendaryItem.validate(keymap)
@@ -34,14 +34,17 @@ function M.bind_keymap(keymap, kind)
     keymap.opts.buffer = vim.api.nvim_get_current_buf()
   end
 
-  require('legendary.utils').set_keymap(keymap)
+  if not is_which_key then
+    require('legendary.utils').set_keymap(keymap)
+  end
+
   require('legendary.formatter').update_padding(keymap)
   table.insert(keymaps, keymap)
 end
 
 --- Bind a list of keymaps with legendary.nvim
 ---@param new_keymaps LegendaryItem[]
-function M.bind_keymaps(new_keymaps, kind)
+function M.bind_keymaps(new_keymaps, kind, is_which_key)
   if not new_keymaps or type(new_keymaps) ~= 'table' then
     return
   end
@@ -54,7 +57,7 @@ function M.bind_keymaps(new_keymaps, kind)
   end
 
   vim.tbl_map(function(keymap)
-    M.bind_keymap(keymap, kind)
+    M.bind_keymap(keymap, kind, is_which_key)
   end, new_keymaps)
 end
 

--- a/lua/legendary/compat/which-key.lua
+++ b/lua/legendary/compat/which-key.lua
@@ -41,9 +41,13 @@ end
 --- Bind a which-key.nvim table with legendary.nvim
 ---@param wk_tbls table
 ---@param wk_opts table
-function M.bind_whichkey(wk_tbls, wk_opts)
+---@param do_binding boolean whether or not to actually bind the keymaps, true by default
+function M.bind_whichkey(wk_tbls, wk_opts, do_binding)
+  if do_binding == nil then
+    do_binding = true
+  end
   local legendary_tbls = M.parse_whichkey(wk_tbls, wk_opts)
-  require('legendary').bind_keymaps(legendary_tbls)
+  require('legendary').bind_keymaps(legendary_tbls, nil, do_binding)
 end
 
 --- Enable auto-registering of which-key.nvim tables
@@ -52,7 +56,7 @@ function M.whichkey_listen()
   local wk = require('which-key')
   local original = wk.register
   local listener = function(whichkey_tbls, whichkey_opts)
-    M.bind_whichkey(whichkey_tbls, whichkey_opts)
+    M.bind_whichkey(whichkey_tbls, whichkey_opts, false)
     original(whichkey_tbls, whichkey_opts)
   end
   wk.register = listener

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -18,6 +18,7 @@ local M = {
   which_key = {
     mappings = {},
     opts = {},
+    do_binding = true,
   },
   auto_register_which_key = true,
   scratchpad = {
@@ -50,9 +51,14 @@ function M.setup(new_config)
   M.keymaps = new_config.keymaps or M.keymaps
   M.commands = new_config.commands or M.commands
   M.autocmds = new_config.autocmds or M.autocmds
-  M.which_key = new_config.which_key and new_config.which_key.mappings and new_config.which_key or M.which_key
   M.auto_register_which_key = default_bool(new_config.auto_register_which_key, M.auto_register_which_key)
   M.scratchpad = new_config.scratchpad or M.scratchpad
+
+  new_config.which_key = new_config.which_key or {}
+  M.which_key.mappings = new_config.which_key.mappings or M.which_key.mappings
+  M.which_key.opts = new_config.which_key.opts or M.which_key.opts
+  M.which_key.do_binding = default_bool(new_config.which_key.do_binding, M.which_key.do_binding)
+
   require('legendary.types').LegendaryConfig.validate(M)
 end
 

--- a/lua/legendary/init.lua
+++ b/lua/legendary/init.lua
@@ -40,7 +40,7 @@ function M.setup(new_config)
   end
 
   if config.which_key and config.which_key.mappings and #config.which_key.mappings > 0 then
-    require('legendary').bind_whichkey(config.which_key.mappings, config.which_key.opts)
+    require('legendary').bind_whichkey(config.which_key.mappings, config.which_key.opts, config.which_key.do_binding)
   end
 
   if config.auto_register_which_key then


### PR DESCRIPTION
## How to Test

1. Register which-key.nvim tables with legendary.nvim through `setup()` and make sure they work both with `do_binding = true` and `do_binding =  false`
2. Register which-key.nvim tables with legendary.nvim through `require('legendary').bind_whichkey(tables, opts, true)` and through `require('legendary').bind_whichkey(tables, opts, false)` and make sure both work (when false, you'll have to have which-key bind them because legendary won't)
3. Register which-key.nvim tables with the legendary.nvim auto-register functionality by calling `require('legendary').setup()` before calling `require('which-key').register()` and make sure they work

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
