### PR TITLE
Use nvim_create_user_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ local commands = {
 }
 ```
 
-You can also pass options to the command via the `opts` property, see `:h nvim_add_user_command` to
+You can also pass options to the command via the `opts` property, see `:h nvim_create_user_command` to
 see available options. In addition to those options, `legendary.nvim` adds handling for an additional
 `buffer` option (a buffer handle, or `0` for current buffer), which will cause the command to be bound
 as a buffer-local command.

--- a/doc/legendary.txt
+++ b/doc/legendary.txt
@@ -324,7 +324,7 @@ command name instead of a key code.
 
 
 You can also pass options to the command via the `opts` property, see `:h
-nvim_add_user_command` to see available options. In addition to those options,
+nvim_create_user_command` to see available options. In addition to those options,
 `legendary.nvim` adds handling for an additional `buffer` option (a buffer
 handle, or `0` for current buffer), which will cause the command to be bound as
 a buffer-local command.

--- a/lua/legendary/utils.lua
+++ b/lua/legendary/utils.lua
@@ -238,7 +238,7 @@ function M.set_command(cmd)
     opts.buffer = nil
     vim.api.nvim_buf_add_user_command(buffer, M.strip_leading_cmd_char(cmd[1]), cmd[2], opts)
   else
-    vim.api.nvim_add_user_command(M.strip_leading_cmd_char(cmd[1]), cmd[2], opts)
+    vim.api.nvim_create_user_command(M.strip_leading_cmd_char(cmd[1]), cmd[2], opts)
   end
 end
 


### PR DESCRIPTION
`nvim_add_user_command` has been renamed to `nvim_create_user_command` in https://github.com/neovim/neovim/pull/18071

Simply replace all occurrences of the old name with the new one.

## How to Test

1. Adding a command does not trigger `attempt to call field 'nvim_add_user_command' (a nil value)`

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
