### PR TITLE
check group based on type for which-key

### DIFF
--- a/lua/legendary/compat/which-key.lua
+++ b/lua/legendary/compat/which-key.lua
@@ -28,7 +28,7 @@ function M.parse_whichkey(which_key_tbls, which_key_opts)
 
 
 
-      if not wk.label or #(wk.group or '') == 0 or wk.buf ~= nil then
+      if not wk.label or ((type(wk.group) == 'boolean' and not wk.group) or (#(tostring(wk.group) or '') == 0)) or wk.buf ~= nil then
          goto continue
       end
 

--- a/teal/legendary/compat/which-key.tl
+++ b/teal/legendary/compat/which-key.tl
@@ -28,7 +28,7 @@ function M.parse_whichkey(which_key_tbls: {table}, which_key_opts: table): {Lege
     -- check wk.group because these don't represent standalone keymaps
     -- they basically represent a "folder" of other keymaps
     -- TODO support which-key mappings with buf values
-    if not wk.label or #(wk.group as string or '') == 0 or wk.buf ~= nil then
+    if not wk.label or ((type(wk.group) == 'boolean' and not wk.group) or (#(tostring(wk.group) or '') == 0)) or wk.buf ~= nil then
       goto continue
     end
 


### PR DESCRIPTION
Looks like I missed a which-key bug while rewriting in teal.

Resolves: #116 

## How to Test

1. Setup keys with which-key and ensure it doesn't break

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
