### PR TITLE
set default opts to empty table

### DIFF
--- a/lua/legendary/utils.lua
+++ b/lua/legendary/utils.lua
@@ -314,7 +314,7 @@ end
 
 function M.resolve_opts(item, mode)
    if not vim.startswith(item.kind, 'legendary.keymap') then
-      return (item).opts
+      return ((item).opts) or {}
    end
 
    local params = M.resolve_keymap(item)
@@ -327,7 +327,7 @@ function M.resolve_opts(item, mode)
    end, params))[1]
    if keymap_params then
       local keymap_params_array = keymap_params
-      return keymap_params_array[#keymap_params_array]
+      return keymap_params_array[#keymap_params_array] or {}
    end
 
    return {}

--- a/teal/legendary/utils.tl
+++ b/teal/legendary/utils.tl
@@ -314,7 +314,7 @@ end
 ---@param mode string
 function M.resolve_opts(item: LegendaryItem, mode: string | nil): {string:any}
   if not vim.startswith(item.kind, 'legendary.keymap') then
-    return (item as table).opts as {string:any}
+    return ((item as table).opts as {string:any}) or {}
   end
 
   local params = M.resolve_keymap(item as LegendaryKeymap)
@@ -327,7 +327,7 @@ function M.resolve_opts(item: LegendaryItem, mode: string | nil): {string:any}
   end, params as {string}) as table)[1]
   if keymap_params then
     local keymap_params_array = keymap_params as {{string:any}}
-    return keymap_params_array[#keymap_params_array]
+    return keymap_params_array[#keymap_params_array] or {}
   end
 
   return {}


### PR DESCRIPTION
Resolves: #120 

## How to Test

1. Create a command through legendary
2. Try to run it through the legendary finder
 
## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
