### PR TITLE
let which-key handle key binding if which-key integration is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,11 @@ require('legendary').setup({
     -- or alternatively have them auto-register,
     -- see section on which-key integration
     mappings = {},
-    opts = {}
+    opts = {},
+    -- controls whether legendary.nvim actually binds they keymaps,
+    -- or if you want to let which-key.nvim handle the bindings.
+    -- if not passed, true by default
+    do_binding = {},
   },
   -- Automatically add which-key tables to legendary
   -- see "which-key.nvim Integration" below for more details
@@ -148,13 +152,24 @@ require('legendary').setup({
   which_key = {
     mappings = your_which_key_tables,
     opts = your_which_key_opts,
+    -- false if which-key.nvim handles binding them,
+    -- set to true if you want legendary.nvim to handle binding
+    -- the mappings; if not passed, true by default
+    do_binding = false,
   },
 })
 
 -- or, if you'd prefer to manually register with legendary.nvim
 require('legendary').setup({ auto_register_which_key = false })
 require('which-key').register(your_which_key_tables, your_which_key_opts)
-require('legendary').bind_whichkey(your_which_key_tables, your_which_key_opts)
+require('legendary').bind_whichkey(
+  your_which_key_tables,
+  your_which_key_opts,
+  -- false if which-key.nvim handles binding them,
+  -- set to true if you want legendary.nvim to handle binding
+  -- the mappings; if not passed, true by default
+  false,
+)
 ```
 
 ## Table Structures

--- a/lua/legendary/bindings.lua
+++ b/lua/legendary/bindings.lua
@@ -111,7 +111,6 @@ local function bind_autocmd(autocmd, group, kind)
 
    if not vim.api.nvim_create_augroup then
       require('legendary.utils').notify(
-
       'Sorry, managing autocmds via legendary.nvim is only supported on Neovim 0.7+ (requires `vim.api.nvim_create_augroup` and `vim.api.nvim_create_autocmd` API functions).')
 
       return

--- a/lua/legendary/compat/which-key.lua
+++ b/lua/legendary/compat/which-key.lua
@@ -17,7 +17,8 @@ end
 
 
 
-function M.parse_whichkey(which_key_tbls, which_key_opts)
+
+function M.parse_whichkey(which_key_tbls, which_key_opts, do_binding)
    local wk_parsed = ((_G['require']('which-key.keys')).parse_mappings)(
    {},
    which_key_tbls,
@@ -36,14 +37,23 @@ function M.parse_whichkey(which_key_tbls, which_key_opts)
 
       ::continue::
    end, wk_parsed)
+
+   if not do_binding then
+      legendary_tbls = vim.tbl_map(function(item)
+         item[2] = nil
+         return item
+      end, legendary_tbls)
+   end
+
    return legendary_tbls
 end
 
 
 
 
-function M.bind_whichkey(wk_tbls, wk_opts)
-   local legendary_tbls = M.parse_whichkey(wk_tbls, wk_opts)
+
+function M.bind_whichkey(wk_tbls, wk_opts, do_binding)
+   local legendary_tbls = M.parse_whichkey(wk_tbls, wk_opts, do_binding)
    require('legendary.bindings').bind_keymaps(legendary_tbls)
 end
 
@@ -53,7 +63,7 @@ function M.whichkey_listen()
    local wk = (_G['require']('which-key'))
    local original = wk.register
    local listener = function(whichkey_tbls, whichkey_opts)
-      M.bind_whichkey(whichkey_tbls, whichkey_opts)
+      M.bind_whichkey(whichkey_tbls, whichkey_opts, false)
       original(whichkey_tbls, whichkey_opts)
    end
    wk.register = listener

--- a/lua/legendary/compat/which-key.lua
+++ b/lua/legendary/compat/which-key.lua
@@ -22,6 +22,9 @@ end
 
 
 function M.parse_whichkey(which_key_tbls, which_key_opts, do_binding)
+   if do_binding == nil then
+      do_binding = true
+   end
    local wk_parsed = ((_G['require']('which-key.keys')).parse_mappings)(
    {},
    which_key_tbls,

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -18,6 +18,7 @@ local M = {
    which_key = {
       mappings = {},
       opts = {},
+      do_binding = true,
    },
    auto_register_which_key = true,
    scratchpad = {
@@ -30,6 +31,18 @@ local function default_bool(value, default)
       return default
    end
    return value
+end
+
+local function default_whichkey(new_config)
+   if not new_config then
+      return M.which_key
+   end
+
+   return {
+      mappings = new_config.mappings or {},
+      opts = new_config.opts or {},
+      do_binding = default_bool(new_config.do_binding, true),
+   }
 end
 
 
@@ -51,7 +64,7 @@ function M.setup(new_config)
    M.keymaps = (new_config.keymaps or M.keymaps)
    M.commands = (new_config.commands or M.commands)
    M.autocmds = (new_config.autocmds or M.autocmds)
-   M.which_key = (new_config.which_key and (new_config.which_key).mappings and new_config.which_key or M.which_key)
+   M.which_key = default_whichkey(new_config.which_key)
    M.auto_register_which_key = default_bool(new_config.auto_register_which_key, M.auto_register_which_key)
    M.scratchpad = (new_config.scratchpad or M.scratchpad)
    require('legendary.types').validate_config(M)

--- a/lua/legendary/init.lua
+++ b/lua/legendary/init.lua
@@ -1,4 +1,4 @@
-local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local pairs = _tl_compat and _tl_compat.pairs or pairs; local pcall = _tl_compat and _tl_compat.pcall or pcall; local string = _tl_compat and _tl_compat.string or string; require('legendary.types')
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local pcall = _tl_compat and _tl_compat.pcall or pcall; local string = _tl_compat and _tl_compat.string or string; require('legendary.types')
 
 local M = {}
 
@@ -53,17 +53,6 @@ M.setup = function(new_config)
       if whichkey_is_loaded then
          require('legendary.compat.which-key').whichkey_listen()
       end
-   end
-end
-
-if not vim.keymap or not vim.keymap.set then
-   local function print_err()
-      require('legendary.utils').notify('Sorry, legendary.nvim requires Neovim 0.7.0 or higher!')
-   end
-
-   print_err()
-   for key, _ in pairs(M) do
-      M[key] = print_err
    end
 end
 

--- a/lua/legendary/init.lua
+++ b/lua/legendary/init.lua
@@ -45,7 +45,11 @@ M.setup = function(new_config)
    end
 
    if config.which_key and config.which_key.mappings and #config.which_key.mappings > 0 then
-      require('legendary.compat.which-key').bind_whichkey(config.which_key.mappings, config.which_key.opts)
+      require('legendary.compat.which-key').bind_whichkey(
+      config.which_key.mappings,
+      config.which_key.opts,
+      config.which_key.do_binding)
+
    end
 
    if config.auto_register_which_key then

--- a/lua/legendary/types.lua
+++ b/lua/legendary/types.lua
@@ -74,6 +74,7 @@ unpack = ((_G).unpack or _tl_table_unpack)
 
 
 
+
  LegendaryScratchpadDisplay = {}
 
 

--- a/lua/legendary/utils.lua
+++ b/lua/legendary/utils.lua
@@ -1,6 +1,12 @@
 local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local pairs = _tl_compat and _tl_compat.pairs or pairs; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; require('legendary.types')
 local M = {}
 
+function M.notify(msg, level, title)
+   level = level or vim.log.levels.ERROR
+   title = title or 'legendary.nvim'
+   vim.notify(msg, level, { title = title })
+end
+
 
 function M.get_marks()
    local cursor = vim.api.nvim_win_get_cursor(0)
@@ -164,6 +170,11 @@ function M.set_keymap(keymap)
 
 
    if type(keymap[2]) ~= 'string' and type(keymap[2]) ~= 'function' and type(keymap[2]) ~= 'table' then
+      return
+   end
+
+   if not vim.keymap or not vim.keymap.set then
+      M.notify('Sorry, binding keymaps with legendary.nvim requires Neovim 0.7.0 or higher!')
       return
    end
 
@@ -336,12 +347,6 @@ end
 
 function M.send_escape_key()
    vim.api.nvim_feedkeys(vim.api.nvim_eval('"\\<esc>"'), 'n', true)
-end
-
-function M.notify(msg, level, title)
-   level = level or vim.log.levels.ERROR
-   title = title or 'legendary.nvim'
-   vim.notify(msg, level, { title = title })
 end
 
 return M

--- a/teal/legendary/bindings.tl
+++ b/teal/legendary/bindings.tl
@@ -111,7 +111,6 @@ local function bind_autocmd(autocmd: LegendaryAutocmd, group: string | nil, kind
 
   if not vim.api.nvim_create_augroup then
     require('legendary.utils').notify(
-      --luacheck: ignore
       'Sorry, managing autocmds via legendary.nvim is only supported on Neovim 0.7+ (requires `vim.api.nvim_create_augroup` and `vim.api.nvim_create_autocmd` API functions).'
     )
     return

--- a/teal/legendary/compat/which-key.tl
+++ b/teal/legendary/compat/which-key.tl
@@ -22,6 +22,9 @@ end
 ---@param do_binding boolean whether to bind the keymaps or let which-key handle it
 ---@return LegendaryItem[]
 function M.parse_whichkey(which_key_tbls: {table}, which_key_opts: table, do_binding: boolean): {LegendaryKeymap}
+  if do_binding == nil then
+    do_binding = true
+  end
   local wk_parsed = ((_G['require']('which-key.keys') as table).parse_mappings as function(_: table, tbls: {table}, prefix: string): table)(
     {},
     which_key_tbls,

--- a/teal/legendary/compat/which-key.tl
+++ b/teal/legendary/compat/which-key.tl
@@ -16,8 +16,9 @@ end
 --- and parse them into legendary.nvim tables
 ---@param which_key_tbls table[]
 ---@param which_key_opts table
+---@param do_binding boolean whether to bind the keymaps or let which-key handle it
 ---@return LegendaryItem[]
-function M.parse_whichkey(which_key_tbls: {table}, which_key_opts: table): {LegendaryKeymap}
+function M.parse_whichkey(which_key_tbls: {table}, which_key_opts: table, do_binding: boolean): {LegendaryKeymap}
   local wk_parsed = ((_G['require']('which-key.keys') as table).parse_mappings as function(_: table, tbls: {table}, prefix: string): table)(
     {},
     which_key_tbls,
@@ -36,14 +37,23 @@ function M.parse_whichkey(which_key_tbls: {table}, which_key_opts: table): {Lege
 
     ::continue::
   end, wk_parsed)
+
+  if not do_binding then
+    legendary_tbls = vim.tbl_map(function(item: LegendaryKeymap): LegendaryKeymap
+      item[2] = nil
+      return item
+    end, legendary_tbls)
+  end
+
   return legendary_tbls
 end
 
 --- Bind a which-key.nvim table with legendary.nvim
 ---@param wk_tbls table
 ---@param wk_opts table
-function M.bind_whichkey(wk_tbls: {table}, wk_opts: table)
-  local legendary_tbls = M.parse_whichkey(wk_tbls, wk_opts)
+---@param do_binding boolean whether to bind the keymaps or let which-key handle it
+function M.bind_whichkey(wk_tbls: {table}, wk_opts: table, do_binding: boolean)
+  local legendary_tbls = M.parse_whichkey(wk_tbls, wk_opts, do_binding)
   require('legendary.bindings').bind_keymaps(legendary_tbls)
 end
 
@@ -53,7 +63,7 @@ function M.whichkey_listen(): boolean
   local wk = (_G['require']('which-key') as table)
   local original = wk.register as function(tbls: {table}, opts: table)
   local listener = function(whichkey_tbls: {table}, whichkey_opts: table)
-    M.bind_whichkey(whichkey_tbls, whichkey_opts)
+    M.bind_whichkey(whichkey_tbls, whichkey_opts, false)
     original(whichkey_tbls, whichkey_opts)
   end
   wk.register = listener

--- a/teal/legendary/config.tl
+++ b/teal/legendary/config.tl
@@ -18,6 +18,7 @@ local M: LegendaryConfig = {
   which_key = {
     mappings = {},
     opts = {},
+    do_binding = true,
   },
   auto_register_which_key = true,
   scratchpad = {
@@ -30,6 +31,18 @@ local function default_bool(value: boolean | nil, default: boolean): boolean
     return default
   end
   return value
+end
+
+local function default_whichkey(new_config: table): LegendaryWhichKeys
+  if not new_config then
+    return M.which_key
+  end
+
+  return {
+    mappings = new_config.mappings or {},
+    opts = new_config.opts or {},
+    do_binding = default_bool(new_config.do_binding as boolean | nil, true)
+  }
 end
 
 ---Set user configuration
@@ -51,7 +64,7 @@ function M.setup(new_config: table): LegendaryConfig
   M.keymaps = (new_config.keymaps or M.keymaps) as {LegendaryKeymap}
   M.commands = (new_config.commands or M.commands) as {LegendaryCommand}
   M.autocmds = (new_config.autocmds or M.autocmds) as {LegendaryAugroup}
-  M.which_key = (new_config.which_key and (new_config.which_key as table).mappings and new_config.which_key or M.which_key) as LegendaryWhichKeys
+  M.which_key = default_whichkey(new_config.which_key as table)
   M.auto_register_which_key = default_bool(new_config.auto_register_which_key as boolean | nil, M.auto_register_which_key)
   M.scratchpad = (new_config.scratchpad or M.scratchpad) as LegendaryScratchpadConfig
   require('legendary.types').validate_config(M)

--- a/teal/legendary/init.tl
+++ b/teal/legendary/init.tl
@@ -45,7 +45,11 @@ M.setup = function(new_config: table)
   end
 
   if config.which_key and config.which_key.mappings and #config.which_key.mappings > 0 then
-    require('legendary.compat.which-key').bind_whichkey(config.which_key.mappings, config.which_key.opts)
+    require('legendary.compat.which-key').bind_whichkey(
+      config.which_key.mappings,
+      config.which_key.opts,
+      config.which_key.do_binding
+    )
   end
 
   if config.auto_register_which_key then

--- a/teal/legendary/init.tl
+++ b/teal/legendary/init.tl
@@ -56,15 +56,4 @@ M.setup = function(new_config: table)
   end
 end
 
-if not vim.keymap or not vim.keymap.set then
-  local function print_err()
-    require('legendary.utils').notify('Sorry, legendary.nvim requires Neovim 0.7.0 or higher!')
-  end
-
-  print_err()
-  for key, _ in pairs(M) do
-    M[key] = print_err
-  end
-end
-
 return M

--- a/teal/legendary/types.tl
+++ b/teal/legendary/types.tl
@@ -72,6 +72,7 @@ end
 global record LegendaryWhichKeys
    mappings: {table}
    opts: table
+   do_binding: boolean
 end
 
 global enum LegendaryScratchpadDisplay

--- a/teal/legendary/utils.tl
+++ b/teal/legendary/utils.tl
@@ -1,6 +1,12 @@
 require('legendary.types')
 local M = {}
 
+function M.notify(msg: string, level: integer | nil, title: string | nil)
+  level = level or vim.log.levels.ERROR
+  title = title or 'legendary.nvim'
+  vim.notify(msg, level, { title = title })
+end
+
 --- Get visual marks in format {start_line, start_col, end_line, end_col}
 function M.get_marks(): table
   local cursor = vim.api.nvim_win_get_cursor(0)
@@ -164,6 +170,11 @@ function M.set_keymap(keymap: LegendaryKeymap)
 
   -- if not a keymap the user wants us to bind, bail
   if type(keymap[2]) ~= 'string' and type(keymap[2]) ~= 'function' and type(keymap[2]) ~= 'table' then
+    return
+  end
+
+  if not vim.keymap or not vim.keymap.set then
+    M.notify('Sorry, binding keymaps with legendary.nvim requires Neovim 0.7.0 or higher!')
     return
   end
 
@@ -336,12 +347,6 @@ end
 --- Helper function to send <ESC> properly
 function M.send_escape_key()
   vim.api.nvim_feedkeys(vim.api.nvim_eval('"\\<esc>"') as string, 'n', true)
-end
-
-function M.notify(msg: string, level: integer | nil, title: string | nil)
-  level = level or vim.log.levels.ERROR
-  title = title or 'legendary.nvim'
-  vim.notify(msg, level, { title = title })
 end
 
 return M


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #[issue number] <!-- If this PR fixes an open issue, please link it here -->

## How to Test

1. Please leave detailed testing instructions

## Testing for Regressions

I have tested the following:

- [ ] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [ ] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [ ] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [ ] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [ ] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
