### PR TITLE
Allow separate descriptions per-mode

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,11 +17,18 @@ jobs:
       uses: leafo/gh-actions-lua@v8
       with:
         luaVersion: "5.1.5"
+    - name: Run Stylua
+      uses: JohnnyMorganz/stylua-action@1.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --check tests/
+        version: 0.10.1
     - name: Setup 'luarocks'
       uses: leafo/gh-actions-luarocks@v4
     - name: Instal Teal Compiler
       run: |
         luarocks install tl
+        luarocks install luacheck
     - name: Checkout teal-types
       uses: actions/checkout@v2
       with: # TODO change this to teal-language/teal-types when this PR is merged: https://github.com/teal-language/teal-types/pull/35

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,15 +25,10 @@ jobs:
         version: 0.10.1
     - name: Setup 'luarocks'
       uses: leafo/gh-actions-luarocks@v4
-    - name: Instal Teal Compiler
+    - name: Install Teal Compiler
       run: |
         luarocks install tl
         luarocks install luacheck
-    - name: Checkout teal-types
-      uses: actions/checkout@v2
-      with: # TODO change this to teal-language/teal-types when this PR is merged: https://github.com/teal-language/teal-types/pull/35
-        repository: mrjones2014/teal-types
-        path: vendor/plenary.nvim
     - name: Run Checks and Ensure Teal Build Up To Date
       run: |
         make check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
       with: # TODO change this to teal-language/teal-types when this PR is merged: https://github.com/teal-language/teal-types/pull/35
         repository: mrjones2014/teal-types
         path: vendor/plenary.nvim
-    - name: Ensure Teal Build Up To Date
+    - name: Run Checks and Ensure Teal Build Up To Date
       run: |
         make check
         make build

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,29 @@ update-test-deps: ensure-test-deps
 test: ensure-test-deps
 	nvim --headless --noplugin -u tests/testrc.lua -c "PlenaryBustedDirectory tests/ { minimal_init = 'tests/testrc.lua' }"
 
-.PHONY: check
-check:
+.PHONY: check-teal
+check-teal:
+	@echo "Running \`tl check\`..."
 	@cd ./teal/ && \
 	tl check ./**/*.tl && \
 	echo "No type errors found" && \
 	cd .. && \
-	luacheck tests/ && \
-	stylua  tests/
+	echo ""
+
+.PHONY: check-luacheck
+check-luacheck:
+	@echo "Running \`luacheck\`..."
+	@luacheck tests/
+	@echo ""
+
+.PHONY: check-stylua # stylua gets run through a separate GitHub Action in CI
+check-stylua:
+	@if test -z "$$CI"; then echo "Running \`stylua\`..." && stylua tests/ && echo "No stylua errors found.\n"; fi
+
+.PHONY: check
+check: check-teal
+check: check-luacheck
+check: check-stylua
 
 .PHONY: gen-types
 gen-types:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ check:
 	@cd ./teal/ && \
 	tl check ./**/*.tl && \
 	echo "No type errors found" && \
-	cd ..
+	cd .. && \
+	luacheck tests/ && \
+	stylua  tests/
 
 .PHONY: gen-types
 gen-types:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ test: ensure-test-deps
 check:
 	@cd ./teal/ && \
 	tl check ./**/*.tl && \
+	echo "No type errors found" && \
 	cd ..
 
 .PHONY: gen-types

--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ require('legendary').bind_whichkey(your_which_key_tables, your_which_key_opts)
 
 The tables for keymaps, commands, and `augroup`/`autocmd`s are all similar.
 
+Descriptions can be specified either in the top-level `description` property
+on each table, or inside the `opts` table as `opts.desc = 'Description goes here'`.
+
 For `autocmd`s, you must include a `description` property for it to appear in the finder.
 This is a design decision because keymaps and commands are frequently executed manually,
 so they should appear in the finder by default, while executing `autocmd`s manually with
@@ -219,6 +222,37 @@ local keymaps = {
     {
       n = { ':CommentToggle<CR>' opts = { noremap = true } },
       v = { ':VisualCommentToggle<CR>' opts = { silent = false } }
+    },
+    description = 'Toggle comment'
+    -- if outer opts exist, the inner opts tables will be merged,
+    -- with the inner opts taking precedence
+    opts = { expr = false }
+  }
+}
+```
+
+If you want the per-mode mappings to be treated as separate keymaps,
+you can specify a separate description per-mode:
+
+```lua
+local keymaps = {
+  {
+    '<leader>c',
+    {
+      n = {
+        ':Something<CR>',
+        description = 'Something in normal mode',
+        opts = { noremap = true }
+      },
+      v = {
+        ':SomethingElse<CR>'
+        opts = {
+          -- you can also specify description through opts.desc
+          -- if you prefer
+          desc = 'Something else in visual mode',
+          silent = false,
+        }
+      }
     },
     description = 'Toggle comment'
     -- if outer opts exist, the inner opts tables will be merged,

--- a/lua/legendary/bindings.lua
+++ b/lua/legendary/bindings.lua
@@ -41,9 +41,6 @@ function M.bind_keymap(keymap, kind)
    utils.set_keymap(keymap)
    require('legendary.formatter').update_padding(keymap)
    for _, resolved_keymap in ipairs(utils.resolve_with_per_mode_description(keymap)) do
-      if resolved_keymap[1] == '<leader>l' then
-         print(vim.inspect(resolved_keymap))
-      end
       keymap.id = next_id()
       table.insert(keymaps, resolved_keymap)
    end
@@ -206,9 +203,9 @@ end
 
 function M.find(item_kind)
    item_kind = item_kind or ''
-   local current_mode = vim.fn.mode()
+   local current_mode = (vim.fn.mode() or '')
    local visual_selection = nil
-   if current_mode and current_mode:sub(1, 1):lower() == 'v' then
+   if utils.is_visual_mode(current_mode) then
       visual_selection = utils.get_marks()
       utils.send_escape_key()
    end

--- a/lua/legendary/bindings.lua
+++ b/lua/legendary/bindings.lua
@@ -13,21 +13,24 @@ local keymaps = require('legendary.config').keymaps
 local commands = require('legendary.config').commands
 local autocmds = require('legendary.config').autocmds
 
+local utils = require('legendary.utils')
+
 local formatter = require('legendary.formatter')
 
 
 
 function M.bind_keymap(keymap, kind)
-   keymap.kind = kind or 'legendary.keymap'
+   keymap = utils.resolve_description(keymap)
+   keymap.kind = (kind or 'legendary.keymap')
    keymap.id = next_id()
    types.validate_keymap(keymap)
 
    if not keymap or type(keymap) ~= 'table' then
-      require('legendary.utils').notify(string.format('Expected table, got %s', type(keymap)))
+      utils.notify(string.format('Expected table, got %s', type(keymap)))
       return
    end
 
-   if require('legendary.utils').list_contains(keymaps, keymap) then
+   if utils.list_contains(keymaps, keymap) then
       return
    end
 
@@ -35,9 +38,15 @@ function M.bind_keymap(keymap, kind)
       keymap.opts.buffer = vim.api.nvim_get_current_buf()
    end
 
-   require('legendary.utils').set_keymap(keymap)
+   utils.set_keymap(keymap)
    require('legendary.formatter').update_padding(keymap)
-   table.insert(keymaps, keymap)
+   for _, resolved_keymap in ipairs(utils.resolve_with_per_mode_description(keymap)) do
+      if resolved_keymap[1] == '<leader>l' then
+         print(vim.inspect(resolved_keymap))
+      end
+      keymap.id = next_id()
+      table.insert(keymaps, resolved_keymap)
+   end
 end
 
 
@@ -48,7 +57,7 @@ function M.bind_keymaps(new_keymaps, kind)
    end
 
    if not vim.tbl_islist(new_keymaps) then
-      require('legendary.utils').notify(
+      utils.notify(
       string.format('Expected list-like table, got %s, at require("legendary").bind_keymaps', type(new_keymaps)))
 
       return
@@ -62,11 +71,12 @@ end
 
 
 function M.bind_command(cmd, kind)
-   cmd.kind = kind or 'legendary.command'
+   cmd = utils.resolve_description(cmd)
+   cmd.kind = (kind or 'legendary.command')
    cmd.id = next_id()
    types.validate_command(cmd)
    if not cmd or type(cmd) ~= 'table' then
-      require('legendary.utils').notify(string.format('Expected table, got %s', type(cmd)))
+      utils.notify(string.format('Expected table, got %s', type(cmd)))
       return
    end
 
@@ -74,11 +84,11 @@ function M.bind_command(cmd, kind)
       cmd.opts.buffer = vim.api.nvim_get_current_buf()
    end
 
-   if require('legendary.utils').list_contains(commands, cmd) then
+   if utils.list_contains(commands, cmd) then
       return
    end
 
-   require('legendary.utils').set_command(cmd)
+   utils.set_command(cmd)
    require('legendary.formatter').update_padding(cmd)
    table.insert(commands, cmd)
 end
@@ -91,7 +101,7 @@ function M.bind_commands(cmds, kind)
    end
 
    if not vim.tbl_islist(cmds) then
-      require('legendary.utils').notify(
+      utils.notify(
       string.format('Expected list-like table, got %s, at require("legendary").bind_commands', type(cmds)))
 
       return
@@ -105,12 +115,13 @@ end
 
 
 local function bind_autocmd(autocmd, group, kind)
-   autocmd.kind = kind or 'legendary.autocmd'
+   autocmd = utils.resolve_description(autocmd)
+   autocmd.kind = (kind or 'legendary.autocmd')
    autocmd.id = next_id()
    types.validate_autocmd(autocmd)
 
    if not vim.api.nvim_create_augroup then
-      require('legendary.utils').notify(
+      utils.notify(
 
       'Sorry, managing autocmds via legendary.nvim is only supported on Neovim 0.7+ (requires `vim.api.nvim_create_augroup` and `vim.api.nvim_create_autocmd` API functions).')
 
@@ -118,11 +129,11 @@ local function bind_autocmd(autocmd, group, kind)
    end
 
    if not autocmd or type(autocmd) ~= 'table' then
-      require('legendary.utils').notify(string.format('Expected table, got %s', type(autocmd)))
+      utils.notify(string.format('Expected table, got %s', type(autocmd)))
       return
    end
 
-   if require('legendary.utils').list_contains(autocmds, autocmd) then
+   if utils.list_contains(autocmds, autocmd) then
       return
    end
 
@@ -130,7 +141,7 @@ local function bind_autocmd(autocmd, group, kind)
       autocmd.opts.buffer = vim.api.nvim_get_current_buf()
    end
 
-   require('legendary.utils').set_autocmd(autocmd, group)
+   utils.set_autocmd(autocmd, group)
    if autocmd.description and #autocmd.description > 0 and not (autocmd.opts or {}).once then
       require('legendary.formatter').update_padding(autocmd)
       table.insert(autocmds, autocmd)
@@ -140,9 +151,10 @@ end
 
 
 local function bind_augroup(augroup, kind)
+   augroup = utils.resolve_description(augroup)
    types.validate_augroup(augroup)
    if not vim.api.nvim_create_augroup then
-      require('legendary.utils').notify(
+      utils.notify(
 
       'Sorry, managing autocmds via legendary.nvim is only supported on Neovim 0.7+ (requires `vim.api.nvim_create_augroup` and `vim.api.nvim_create_autocmd` API functions).')
 
@@ -151,7 +163,7 @@ local function bind_augroup(augroup, kind)
 
    local group_name = augroup and augroup.name or ''
    if #group_name == 0 then
-      require('legendary.utils').notify('augroup must have a name')
+      utils.notify('augroup must have a name')
       return
    end
 
@@ -172,15 +184,15 @@ end
 
 
 function M.bind_autocmds(au, kind)
-   if require('legendary.utils').is_user_augroup(au) then
+   if utils.is_user_augroup(au) then
       bind_augroup(au)
-   elseif require('legendary.utils').is_user_autocmd(au) then
+   elseif utils.is_user_autocmd(au) then
       bind_autocmd(au)
    else
       vim.tbl_map(function(augroup_or_autocmd)
-         if require('legendary.utils').is_user_augroup(augroup_or_autocmd) then
+         if utils.is_user_augroup(augroup_or_autocmd) then
             bind_augroup(augroup_or_autocmd, kind)
-         elseif require('legendary.utils').is_user_autocmd(augroup_or_autocmd) then
+         elseif utils.is_user_autocmd(augroup_or_autocmd) then
             bind_autocmd(augroup_or_autocmd, kind)
          end
       end, au)
@@ -197,8 +209,8 @@ function M.find(item_kind)
    local current_mode = vim.fn.mode()
    local visual_selection = nil
    if current_mode and current_mode:sub(1, 1):lower() == 'v' then
-      visual_selection = require('legendary.utils').get_marks()
-      require('legendary.utils').send_escape_key()
+      visual_selection = utils.get_marks()
+      utils.send_escape_key()
    end
    local cursor_position = vim.api.nvim_win_get_cursor(0)
    local items

--- a/lua/legendary/executor.lua
+++ b/lua/legendary/executor.lua
@@ -7,11 +7,7 @@ local function mode_from_table(modes, current_mode)
    end
 
    for _, mode in ipairs(modes) do
-      if mode == 'n' then
-         return mode
-      end
-
-      if mode == 'i' then
+      if mode == 'n' or mode == 'i' or require('legendary.utils').is_visual_mode(mode) then
          return mode
       end
    end
@@ -28,8 +24,13 @@ local function exec(item, mode, visual_selection)
       vim.cmd('stopinsert')
    elseif mode == 'i' then
       vim.cmd('startinsert')
-   elseif mode == 'v' then
+   elseif utils.is_visual_mode(mode) then
       vim.cmd('normal! gv')
+
+      if not utils.is_visual_mode((vim.fn.mode()) or '') then
+         utils.notify('Failed to enter visual mode, aborting execution.')
+         return
+      end
    end
 
    if type(cmd) == 'function' then

--- a/lua/legendary/types.lua
+++ b/lua/legendary/types.lua
@@ -1,6 +1,15 @@
 local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local table = _tl_compat and _tl_compat.table or table; local _tl_table_unpack = unpack or table.unpack
 unpack = ((_G).unpack or _tl_table_unpack)
 
+ LegendaryKind = {}
+
+
+
+
+
+
+
+
  LegendaryModeMappingOpts = {}
 
 

--- a/lua/legendary/utils.lua
+++ b/lua/legendary/utils.lua
@@ -201,8 +201,8 @@ function M.resolve_keymap(keymap)
    if type(keymap[2]) == 'function' and M.has_visual_mode(keymap) then
       local orig = keymap[2]
       keymap[2] = function(visual_selection)
-         local current_mode = vim.fn.mode()
-         if current_mode and current_mode:sub(1, 1):lower() == 'v' then
+         local current_mode = (vim.fn.mode() or '')
+         if M.is_visual_mode(current_mode) then
 
             local marks = visual_selection or M.get_marks()
             M.set_marks(marks)

--- a/teal/legendary/bindings.tl
+++ b/teal/legendary/bindings.tl
@@ -13,21 +13,24 @@ local keymaps = require('legendary.config').keymaps
 local commands = require('legendary.config').commands
 local autocmds = require('legendary.config').autocmds
 
+local utils = require('legendary.utils')
+
 local formatter = require('legendary.formatter')
 
 --- Bind a single keymap with legendary.nvim
 ---@param keymap LegendaryItem
 function M.bind_keymap(keymap: LegendaryKeymap, kind: string | nil)
-  keymap.kind = kind or 'legendary.keymap'
+  keymap = utils.resolve_description(keymap)
+  keymap.kind = (kind or 'legendary.keymap') as LegendaryKind
   keymap.id = next_id()
   types.validate_keymap(keymap)
 
   if not keymap or type(keymap) ~= 'table' then
-    require('legendary.utils').notify(string.format('Expected table, got %s', type(keymap)))
+    utils.notify(string.format('Expected table, got %s', type(keymap)))
     return
   end
 
-  if require('legendary.utils').list_contains(keymaps, keymap) then
+  if utils.list_contains(keymaps, keymap) then
     return
   end
 
@@ -35,9 +38,15 @@ function M.bind_keymap(keymap: LegendaryKeymap, kind: string | nil)
     keymap.opts.buffer = vim.api.nvim_get_current_buf()
   end
 
-  require('legendary.utils').set_keymap(keymap)
+  utils.set_keymap(keymap)
   require('legendary.formatter').update_padding(keymap as LegendaryItem)
-  table.insert(keymaps, keymap)
+  for _, resolved_keymap in ipairs(utils.resolve_with_per_mode_description(keymap)) do
+    if resolved_keymap[1] == '<leader>l' then
+      print(vim.inspect(resolved_keymap))
+    end
+    keymap.id = next_id()
+    table.insert(keymaps, resolved_keymap)
+  end
 end
 
 --- Bind a list of keymaps with legendary.nvim
@@ -48,7 +57,7 @@ function M.bind_keymaps(new_keymaps: {LegendaryKeymap}, kind: string | nil)
   end
 
   if not vim.tbl_islist(new_keymaps) then
-    require('legendary.utils').notify(
+    utils.notify(
       string.format('Expected list-like table, got %s, at require("legendary").bind_keymaps', type(new_keymaps))
     )
     return
@@ -62,11 +71,12 @@ end
 --- Bind a single command with legendary.nvim
 ---@param cmd LegendaryItem
 function M.bind_command(cmd: LegendaryCommand, kind: string | nil)
-  cmd.kind = kind or 'legendary.command'
+  cmd = utils.resolve_description(cmd)
+  cmd.kind = (kind or 'legendary.command') as LegendaryKind
   cmd.id = next_id()
   types.validate_command(cmd)
   if not cmd or type(cmd) ~= 'table' then
-    require('legendary.utils').notify(string.format('Expected table, got %s', type(cmd)))
+    utils.notify(string.format('Expected table, got %s', type(cmd)))
     return
   end
 
@@ -74,11 +84,11 @@ function M.bind_command(cmd: LegendaryCommand, kind: string | nil)
     cmd.opts.buffer = vim.api.nvim_get_current_buf()
   end
 
-  if require('legendary.utils').list_contains(commands, cmd) then
+  if utils.list_contains(commands, cmd) then
     return
   end
 
-  require('legendary.utils').set_command(cmd)
+  utils.set_command(cmd)
   require('legendary.formatter').update_padding(cmd as LegendaryItem)
   table.insert(commands, cmd)
 end
@@ -91,7 +101,7 @@ function M.bind_commands(cmds: {LegendaryCommand}, kind: string | nil)
   end
 
   if not vim.tbl_islist(cmds) then
-    require('legendary.utils').notify(
+    utils.notify(
       string.format('Expected list-like table, got %s, at require("legendary").bind_commands', type(cmds))
     )
     return
@@ -105,12 +115,13 @@ end
 --- Bind a single autocmd with legendary.nvim
 ---@param autocmd LegendaryItem
 local function bind_autocmd(autocmd: LegendaryAutocmd, group: string | nil, kind: string | nil)
-  autocmd.kind = kind or 'legendary.autocmd'
+  autocmd = utils.resolve_description(autocmd)
+  autocmd.kind = (kind or 'legendary.autocmd') as LegendaryKind
   autocmd.id = next_id()
   types.validate_autocmd(autocmd)
 
   if not vim.api.nvim_create_augroup then
-    require('legendary.utils').notify(
+    utils.notify(
       --luacheck: ignore
       'Sorry, managing autocmds via legendary.nvim is only supported on Neovim 0.7+ (requires `vim.api.nvim_create_augroup` and `vim.api.nvim_create_autocmd` API functions).'
     )
@@ -118,11 +129,11 @@ local function bind_autocmd(autocmd: LegendaryAutocmd, group: string | nil, kind
   end
 
   if not autocmd or type(autocmd) ~= 'table' then
-    require('legendary.utils').notify(string.format('Expected table, got %s', type(autocmd)))
+    utils.notify(string.format('Expected table, got %s', type(autocmd)))
     return
   end
 
-  if require('legendary.utils').list_contains(autocmds as {LegendaryAutocmd}, autocmd) then
+  if utils.list_contains(autocmds as {LegendaryAutocmd}, autocmd) then
     return
   end
 
@@ -130,7 +141,7 @@ local function bind_autocmd(autocmd: LegendaryAutocmd, group: string | nil, kind
     autocmd.opts.buffer = vim.api.nvim_get_current_buf()
   end
 
-  require('legendary.utils').set_autocmd(autocmd, group)
+  utils.set_autocmd(autocmd, group)
   if autocmd.description and #autocmd.description > 0 and not (autocmd.opts or {}).once then
     require('legendary.formatter').update_padding(autocmd as LegendaryItem)
     table.insert(autocmds as {LegendaryAutocmd}, autocmd)
@@ -140,9 +151,10 @@ end
 --- Bind an augroup of autocmds
 ---@param augroup LegendaryAugroup
 local function bind_augroup(augroup: LegendaryAugroup, kind: string | nil)
+  augroup = utils.resolve_description(augroup)
   types.validate_augroup(augroup)
   if not vim.api.nvim_create_augroup then
-    require('legendary.utils').notify(
+    utils.notify(
       --luacheck: ignore
       'Sorry, managing autocmds via legendary.nvim is only supported on Neovim 0.7+ (requires `vim.api.nvim_create_augroup` and `vim.api.nvim_create_autocmd` API functions).'
     )
@@ -151,7 +163,7 @@ local function bind_augroup(augroup: LegendaryAugroup, kind: string | nil)
 
   local group_name = augroup and augroup.name or ''
   if #group_name == 0 then
-    require('legendary.utils').notify('augroup must have a name')
+    utils.notify('augroup must have a name')
     return
   end
 
@@ -172,15 +184,15 @@ end
 --- Bind a list of mixed augroups and autocmds
 ---@param au LegendaryAugroup[] | LegendaryItem[]
 function M.bind_autocmds(au: table, kind: string | nil)
-  if require('legendary.utils').is_user_augroup(au as LegendaryAugroup) then
+  if utils.is_user_augroup(au as LegendaryAugroup) then
     bind_augroup(au as LegendaryAugroup)
-  elseif require('legendary.utils').is_user_autocmd(au as LegendaryAutocmd) then
+  elseif utils.is_user_autocmd(au as LegendaryAutocmd) then
     bind_autocmd(au as LegendaryAutocmd)
   else
     vim.tbl_map(function(augroup_or_autocmd: table): nil
-      if require('legendary.utils').is_user_augroup(augroup_or_autocmd as LegendaryAugroup) then
+      if utils.is_user_augroup(augroup_or_autocmd as LegendaryAugroup) then
         bind_augroup(augroup_or_autocmd as LegendaryAugroup, kind)
-      elseif require('legendary.utils').is_user_autocmd(augroup_or_autocmd as LegendaryAutocmd) then
+      elseif utils.is_user_autocmd(augroup_or_autocmd as LegendaryAutocmd) then
         bind_autocmd(augroup_or_autocmd as LegendaryAutocmd, kind)
       end
     end, au)
@@ -197,8 +209,8 @@ function M.find(item_kind: string | nil)
   local current_mode = vim.fn.mode() as string
   local visual_selection: table = nil
   if current_mode and current_mode:sub(1, 1):lower() == 'v' then
-    visual_selection = require('legendary.utils').get_marks()
-    require('legendary.utils').send_escape_key()
+    visual_selection = utils.get_marks()
+    utils.send_escape_key()
   end
   local cursor_position = vim.api.nvim_win_get_cursor(0)
   local items: {LegendaryItem}

--- a/teal/legendary/bindings.tl
+++ b/teal/legendary/bindings.tl
@@ -41,9 +41,6 @@ function M.bind_keymap(keymap: LegendaryKeymap, kind: string | nil)
   utils.set_keymap(keymap)
   require('legendary.formatter').update_padding(keymap as LegendaryItem)
   for _, resolved_keymap in ipairs(utils.resolve_with_per_mode_description(keymap)) do
-    if resolved_keymap[1] == '<leader>l' then
-      print(vim.inspect(resolved_keymap))
-    end
     keymap.id = next_id()
     table.insert(keymaps, resolved_keymap)
   end
@@ -206,9 +203,9 @@ end
 ---@param item_kind string
 function M.find(item_kind: string | nil)
   item_kind = item_kind or ''
-  local current_mode = vim.fn.mode() as string
+  local current_mode = (vim.fn.mode() or '') as string
   local visual_selection: table = nil
-  if current_mode and current_mode:sub(1, 1):lower() == 'v' then
+  if utils.is_visual_mode(current_mode) then
     visual_selection = utils.get_marks()
     utils.send_escape_key()
   end

--- a/teal/legendary/executor.tl
+++ b/teal/legendary/executor.tl
@@ -7,11 +7,7 @@ local function mode_from_table(modes: {string}, current_mode: string): string
   end
 
   for _, mode in ipairs(modes) do
-    if mode == 'n' then
-      return mode
-    end
-
-    if mode == 'i' then
+    if mode == 'n' or mode == 'i' or require('legendary.utils').is_visual_mode(mode) then
       return mode
     end
   end
@@ -28,8 +24,13 @@ local function exec(item: LegendaryItem, mode: string, visual_selection: table)
     vim.cmd('stopinsert')
   elseif mode == 'i' then -- insert mode
     vim.cmd('startinsert')
-  elseif mode == 'v' then -- visual mode
+  elseif utils.is_visual_mode(mode) then -- visual mode
     vim.cmd('normal! gv')
+    -- if failed to go to visual mode, return
+    if not utils.is_visual_mode((vim.fn.mode() as string | nil) or '') then
+      utils.notify('Failed to enter visual mode, aborting execution.')
+      return
+    end
   end
 
   if type(cmd) == 'function' then

--- a/teal/legendary/types.tl
+++ b/teal/legendary/types.tl
@@ -1,6 +1,15 @@
 -- `unpack` is a global in neovim
 global unpack = ((_G as table).unpack or table.unpack) as function(table): any...
 
+global enum LegendaryKind
+   'legendary.keymap'
+   'legendary.keymap.builtin'
+   'legendary.command'
+   'legendary.command.builtin'
+   'legendary.augroup'
+   'legendary.autocmd'
+end
+
 global record LegendaryModeMappingOpts
    {string | function(marks: table | nil): nil}
    opts: table | nil
@@ -25,7 +34,7 @@ global record LegendaryKeymap
    mode: string | {string}
    description: string
    opts: table
-   kind: string
+   kind: LegendaryKind
    id: integer
    unfinished: boolean | nil
 end
@@ -38,7 +47,7 @@ global record LegendaryCommand
    {string | function | nil}
    description: string
    opts: {string: any}
-   kind: string
+   kind: LegendaryKind
    id: integer
    unfinished: boolean | nil
 end
@@ -51,7 +60,7 @@ global record LegendaryAutocmd
    {string | function | nil}
    description: string
    opts: table
-   kind: string
+   kind: LegendaryKind
    id: integer
 end
 
@@ -65,7 +74,7 @@ end
 --- Can be any of the legendary table types
 global record LegendaryItem
    id: integer
-   kind: string
+   kind: LegendaryKind
    description: string | nil
 end
 

--- a/teal/legendary/utils.tl
+++ b/teal/legendary/utils.tl
@@ -2,11 +2,82 @@ require('legendary.types')
 local M = {}
 
 --- Get visual marks in format {start_line, start_col, end_line, end_col}
+--- @return table in format {start_line, start_col, end_line, end_col}
 function M.get_marks(): table
   local cursor = vim.api.nvim_win_get_cursor(0)
   local cline, ccol = cursor[1], cursor[2]
   local vline, vcol = vim.fn.line('v'), vim.fn.col('v')
   return { cline, ccol, vline, vcol }
+end
+
+--- If item.description is not set,
+--- try taking the description from
+--- item.opts.desc
+---@param item T where T is a LegendaryKeymap, LegendaryCommand or LegendaryAutocmd
+---@return T
+function M.resolve_description<T>(item: T): T
+  if not item then
+    return item
+  end
+
+  if (item as table).description and #((item as table).description as string) > 0 then
+    return item
+  end
+
+  if (item as table).opts and ((item as table).opts as table).desc and #(((item as table).opts as table).desc as string) > 0 then
+    (item as table).description = ((item as table).opts as table).desc
+  end
+
+  return item
+end
+
+--- Check if a LegendaryKeymap has per-mode descriptions set
+---@param keymap LegendaryKeymap
+---@return boolean true if the keymap has per-mode descriptions set
+function M.has_per_mode_description(keymap: LegendaryKeymap): boolean
+  if not keymap then
+    return false
+  end
+
+  if type(keymap[2]) ~= 'table' then
+    return false
+  end
+
+  for _, impl in pairs(keymap[2] as table) do
+    impl = M.resolve_description(impl)
+    if #((((impl as table).description) as string | nil) or '') > 0 then
+      return true
+    end
+  end
+  return false
+end
+
+function M.resolve_with_per_mode_description(keymap: LegendaryKeymap): {LegendaryKeymap}
+  if not keymap or type(keymap[2]) ~= 'table' or not M.has_per_mode_description(keymap) then
+    return { keymap }
+  end
+
+  local resolved_tbls: {LegendaryKeymap} = {}
+  for mode, impl in pairs(keymap[2] as table) do
+    local resolved_keymap: LegendaryKeymap = { keymap[1], kind = 'legendary.keymap' }
+    if type(impl) == 'table' then
+      resolved_keymap.opts = vim.tbl_deep_extend(
+        'keep',
+        ((impl as table).opts or {}) as table,
+        keymap.opts or {}
+      )
+      resolved_keymap.mode = mode as string | {string}
+      resolved_keymap.description = (impl as table).description as string
+    else
+      resolved_keymap[2] = impl as string | function(marks: table | nil): nil
+      resolved_keymap.opts = keymap.opts
+      resolved_keymap.description = keymap.description
+    end
+    resolved_keymap = M.resolve_description(resolved_keymap)
+    table.insert(resolved_tbls, resolved_keymap)
+  end
+
+  return resolved_tbls
 end
 
 --- Set visual marks from a table in the format

--- a/teal/legendary/utils.tl
+++ b/teal/legendary/utils.tl
@@ -201,8 +201,8 @@ function M.resolve_keymap(keymap: LegendaryKeymap): table
   if type(keymap[2]) == 'function' and M.has_visual_mode(keymap) then
     local orig = keymap[2] as function(marks: table | nil): nil
     keymap[2] = function(visual_selection: table): nil
-      local current_mode = vim.fn.mode() as string
-      if current_mode and current_mode:sub(1, 1):lower() == 'v' then
+      local current_mode = (vim.fn.mode() or '') as string
+      if M.is_visual_mode(current_mode) then
         -- ensure marks are set
         local marks = visual_selection or M.get_marks()
         M.set_marks(marks)

--- a/teal/legendary/utils.tl
+++ b/teal/legendary/utils.tl
@@ -15,8 +15,8 @@ end
 --- item.opts.desc
 ---@param item T where T is a LegendaryKeymap, LegendaryCommand or LegendaryAutocmd
 ---@return T
-function M.resolve_description<T>(item: T): T
-  if not item then
+function M.resolve_description<T>(item: T, fallback: string | nil): T
+  if not item or type(item) ~= 'table' then
     return item
   end
 
@@ -26,6 +26,10 @@ function M.resolve_description<T>(item: T): T
 
   if (item as table).opts and ((item as table).opts as table).desc and #(((item as table).opts as table).desc as string) > 0 then
     (item as table).description = ((item as table).opts as table).desc
+  end
+
+  if #(((item as table).description or '') as string) == 0 then
+    (item as table).description = fallback
   end
 
   return item
@@ -52,10 +56,15 @@ function M.has_per_mode_description(keymap: LegendaryKeymap): boolean
   return false
 end
 
+--- Get resolved LegendaryKeymaps for a LegendaryKeymap
+--- that may or may not have per-mode descriptions
+--- (and therefore should be treated as separate items)
 function M.resolve_with_per_mode_description(keymap: LegendaryKeymap): {LegendaryKeymap}
   if not keymap or type(keymap[2]) ~= 'table' or not M.has_per_mode_description(keymap) then
     return { keymap }
   end
+
+  keymap = M.resolve_description(keymap)
 
   local resolved_tbls: {LegendaryKeymap} = {}
   for mode, impl in pairs(keymap[2] as table) do
@@ -69,11 +78,16 @@ function M.resolve_with_per_mode_description(keymap: LegendaryKeymap): {Legendar
       resolved_keymap.mode = mode as string | {string}
       resolved_keymap.description = (impl as table).description as string
     else
-      resolved_keymap[2] = impl as string | function(marks: table | nil): nil
+      resolved_keymap.mode = mode as string | {string}
       resolved_keymap.opts = keymap.opts
       resolved_keymap.description = keymap.description
     end
-    resolved_keymap = M.resolve_description(resolved_keymap)
+
+    local fallback_desc = keymap.description or ''
+    if #fallback_desc == 0 then
+      fallback_desc = (keymap.opts and keymap.opts.desc as string) or nil
+    end
+    resolved_keymap = M.resolve_description(resolved_keymap, fallback_desc)
     table.insert(resolved_tbls, resolved_keymap)
   end
 

--- a/tests/legendary/utils_spec.lua
+++ b/tests/legendary/utils_spec.lua
@@ -234,4 +234,67 @@ describe('legendary.utils', function()
       }, result)
     end)
   end)
+
+  describe('resolve_with_per_mode_description', function()
+    it('should return a list with just the input if does not have per-mode descriptions', function()
+      local keymap = {
+        '<leader>l',
+        {
+          n = ':Something<CR>',
+          v = { ':SomethingElse<CR>' },
+        },
+      }
+      local result = utils.resolve_with_per_mode_description(keymap)
+      assert.are.same({ keymap }, result)
+    end)
+
+    it('should return separate LegendaryKeymaps when input has per-mode descriptions', function()
+      local keymap = {
+        '<leader>l',
+        {
+          -- should get outer desc
+          n = ':Something<CR>',
+          v = { ':SomethingElse<CR>', description = 'Something else' },
+          c = { ':AnotherThing<CR>', opts = { desc = 'Another thing' } },
+        },
+        description = 'Something',
+      }
+      local result = utils.resolve_with_per_mode_description(keymap)
+      -- order is not guaranteed, so put the result
+      -- in a known order
+      result = {
+        vim.tbl_filter(function(tbl)
+          return tbl.mode == nil or tbl.mode == 'n'
+        end, result)[1],
+        vim.tbl_filter(function(tbl)
+          return tbl.mode == 'v'
+        end, result)[1],
+        vim.tbl_filter(function(tbl)
+          return tbl.mode == 'c'
+        end, result)[1],
+      }
+      assert.are.same({
+        {
+          '<leader>l',
+          description = 'Something',
+          mode = 'n',
+          kind = 'legendary.keymap',
+        },
+        {
+          '<leader>l',
+          description = 'Something else',
+          mode = 'v',
+          kind = 'legendary.keymap',
+          opts = {},
+        },
+        {
+          '<leader>l',
+          description = 'Another thing',
+          mode = 'c',
+          opts = { desc = 'Another thing' },
+          kind = 'legendary.keymap',
+        },
+      }, result)
+    end)
+  end)
 end)


### PR DESCRIPTION
Allows separate descriptions per-mode. Also adds the ability to specify the description under `item.opts.desc` instead of `item.description` if you prefer (since this is what the Neovim APIs reference internally).

Resolves: #108 

## How to Test

1. Add a keymap which has per-mode mappings, and in each mode, specify either `description` or `opts.desc`
2. Make sure the keymaps work in each mode
3. Make sure the rest of your existing keymaps, commands, and autocmds work

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly