### PR TITLE
check for mode in which-key opts

### DIFF
--- a/lua/legendary/compat/which-key.lua
+++ b/lua/legendary/compat/which-key.lua
@@ -1,11 +1,14 @@
 local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local table = _tl_compat and _tl_compat.table or table; require('legendary.types')
 local M = {}
 
-local function wk_to_legendary(wk)
+local function wk_to_legendary(wk, wk_opts)
    local legendary = {}
    legendary[1] = wk.prefix
    if wk.cmd then
       legendary[2] = wk.cmd
+   end
+   if wk_opts and wk_opts.mode then
+      legendary.mode = wk_opts.mode
    end
    legendary.description = wk.label
    legendary.opts = wk.opts or {}
@@ -32,7 +35,7 @@ function M.parse_whichkey(which_key_tbls, which_key_opts)
          goto continue
       end
 
-      table.insert(legendary_tbls, wk_to_legendary(wk))
+      table.insert(legendary_tbls, wk_to_legendary(wk, which_key_opts))
 
       ::continue::
    end, wk_parsed)

--- a/teal/legendary/compat/which-key.tl
+++ b/teal/legendary/compat/which-key.tl
@@ -1,11 +1,14 @@
 require('legendary.types')
 local M = {}
 
-local function wk_to_legendary(wk: table): LegendaryKeymap
+local function wk_to_legendary(wk: table, wk_opts: table): LegendaryKeymap
   local legendary: table = {}
   legendary[1] = wk.prefix
   if wk.cmd then
     legendary[2] = wk.cmd
+  end
+  if wk_opts and wk_opts.mode then
+    legendary.mode = wk_opts.mode
   end
   legendary.description = wk.label
   legendary.opts = wk.opts or {}
@@ -32,7 +35,7 @@ function M.parse_whichkey(which_key_tbls: {table}, which_key_opts: table): {Lege
       goto continue
     end
 
-    table.insert(legendary_tbls, wk_to_legendary(wk))
+    table.insert(legendary_tbls, wk_to_legendary(wk, which_key_opts))
 
     ::continue::
   end, wk_parsed)


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #127 

## How to Test

1. Set up a keymap via which-key.nvim for a mode other than normal 
2. Check that legendary sees the mode correctly by searching for it in `:Legendary keymaps`

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly