### PR TITLE
Implement item filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,52 @@ To trigger the finder for your configured keymaps, commands, and `augroup`/`auto
 Lua:
 
 ```lua
-require('legendary').find() -- search keymaps, commands, and autocmds
-require('legendary').find('keymaps') -- search keymaps
-require('legendary').find('commands') -- search commands
-require('legendary').find('autocmds') -- search autocmds
+-- search keymaps, commands, and autocmds
+require('legendary').find()
+-- search keymaps
+require('legendary').find('keymaps')
+-- search commands
+require('legendary').find('commands')
+-- search autocmds
+require('legendary').find('autocmds')
 ```
 
 Vim commands:
 
 ```VimL
-:Legendary " search keymaps, commands, and autocmds
-:Legendary keymaps " search keymaps
-:Legendary commands " search commands
-:Legendary autocmds " search autocmds
+" search keymaps, commands, and autocmds
+:Legendary
+
+" search keymaps
+:Legendary keymaps
+
+" search commands
+:Legendary commands
+
+" search autocmds
+:Legendary autocmds
+```
+
+In Lua, you can also specify filters in the second argument. It can be either a function, or a list of functions,
+with the signature `function(item: LegendaryItem): boolean`. There are some pre-made filters in the `legendary.filters`
+module.
+
+```lua
+-- filter keymaps by current mode
+require('legendary').find(nil, require('legendary.filters').current_mode())
+-- filter keymaps by normal mode
+require('legendary').find(nil, require('legendary.filters').mode('n'))
+-- filter keymaps by normal mode and that start with <leader>
+require('legendary').find(nil, {
+  require('legendary.filters').mode('n'),
+  function(item)
+    if not string.find(item.kind, 'keymap') then
+      return true
+    end
+
+    return vim.startswith(item[1], '<leader>')
+  end
+})
 ```
 
 ## Configuration
@@ -450,6 +483,33 @@ require('legendary').bind_autocmds(augroup)
 require('legendary').bind_autocmds(autocmd)
 require('legendary').bind_autocmds({
   -- your augroups and autocmds here
+})
+
+-- search keymaps, commands, and autocmds
+require('legendary').find()
+-- search keymaps
+require('legendary').find('keymaps')
+-- search commands
+require('legendary').find('commands')
+-- search autocmds
+require('legendary').find('autocmds')
+
+-- filter keymaps by current mode
+require('legendary').find(nil, require('legendary.filters').current_mode())
+-- find only keymaps, and filter by current mode
+require('legendary').find('keymaps', require('legendary.filters').current_mode())
+-- filter keymaps by normal mode
+require('legendary').find(nil, require('legendary.filters').mode('n'))
+-- filter keymaps by normal mode and that start with <leader>
+require('legendary').find(nil, {
+  require('legendary.filters').mode('n'),
+  function(item)
+    if not string.find(item.kind, 'keymap') then
+      return true
+    end
+
+    return vim.startswith(item[1], '<leader>')
+  end
 })
 ```
 

--- a/lua/legendary/bindings.lua
+++ b/lua/legendary/bindings.lua
@@ -201,7 +201,7 @@ end
 
 
 
-function M.find(item_kind)
+function M.find(item_kind, filters)
    item_kind = item_kind or ''
    local current_mode = (vim.fn.mode() or '')
    local visual_selection = nil
@@ -224,6 +224,7 @@ function M.find(item_kind)
    end
 
 
+
    if
 require('legendary.config').most_recent_item_at_top and
       last_used_item and
@@ -242,10 +243,33 @@ require('legendary.config').most_recent_item_at_top and
       ::last_used_item_found::
    end
 
+   filters = filters or {}
+   if type(filters) == 'function' then
+      filters = { filters }
+   end
 
-   items = vim.tbl_filter(function(item)
+
+   table.insert(filters, function(item)
       return item.opts == nil or item.opts.buffer == nil or item.opts.buffer == vim.api.nvim_get_current_buf()
-   end, items)
+   end)
+
+   for _, filter in ipairs(filters) do
+      if type(filter) ~= 'function' then
+         utils.notify('Passed an item filter that is not a function', vim.log.levels.WARN)
+         goto skip_filter
+      end
+
+      items = vim.tbl_filter(function(item)
+         local result = filter(item)
+         if type(result) ~= 'boolean' then
+            return true
+         end
+
+         return result
+      end, items)
+
+      ::skip_filter::
+   end
 
    local select_kind = string.format(
    'legendary.%s',

--- a/lua/legendary/filters.lua
+++ b/lua/legendary/filters.lua
@@ -1,0 +1,26 @@
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local string = _tl_compat and _tl_compat.string or string; require('legendary.types')
+
+local M = {}
+
+function M.mode(mode)
+   return function(item)
+
+      if not string.find(item.kind, 'keymap') then
+         return true
+      end
+
+      local keymap = item
+      local keymap_mode = keymap.mode or { 'n' }
+      if type(keymap_mode) == 'string' then
+         keymap_mode = { keymap_mode }
+      end
+
+      return vim.tbl_contains(keymap_mode, mode)
+   end
+end
+
+function M.current_mode()
+   return M.mode((vim.fn.mode() or 'n'))
+end
+
+return M

--- a/lua/legendary/types.lua
+++ b/lua/legendary/types.lua
@@ -78,6 +78,9 @@ unpack = ((_G).unpack or _tl_table_unpack)
 
 
 
+
+ LegendaryItemFilter = {}
+
  LegendaryWhichKeys = {}
 
 

--- a/teal/legendary/bindings.tl
+++ b/teal/legendary/bindings.tl
@@ -201,7 +201,7 @@ end
 --- "keymaps" as a parameter, pass "commands" to find
 --- only commands, pass "autocmds" to find only autocmds.
 ---@param item_kind string
-function M.find(item_kind: string | nil)
+function M.find(item_kind: string | nil, filters: {LegendaryItemFilter} | nil)
   item_kind = item_kind or ''
   local current_mode = (vim.fn.mode() or '') as string
   local visual_selection: table = nil
@@ -223,6 +223,7 @@ function M.find(item_kind: string | nil)
     items = vim.list_extend(items, autocmds as {LegendaryItem})
   end
 
+
   -- only search for last used item if kind matches
   if
     require('legendary.config').most_recent_item_at_top
@@ -242,10 +243,33 @@ function M.find(item_kind: string | nil)
     ::last_used_item_found::
   end
 
+  filters = filters or {}
+  if type(filters) == 'function' then
+    filters = { filters as LegendaryItemFilter }
+  end
+
   -- buffer-specific items should only appear for the current buffer
-  items = vim.tbl_filter(function(item: LegendaryKeymap): boolean
+  table.insert(filters, function(item: LegendaryItem): boolean
     return item.opts == nil or item.opts.buffer == nil or item.opts.buffer == vim.api.nvim_get_current_buf()
-  end, items) as {LegendaryItem}
+  end)
+
+  for _, filter in ipairs(filters as {LegendaryItemFilter}) do
+    if type(filter) ~= 'function' then
+      utils.notify('Passed an item filter that is not a function', vim.log.levels.WARN)
+      goto skip_filter
+    end
+
+    items = vim.tbl_filter(function(item: LegendaryItem): boolean
+      local result = filter(item)
+      if type(result) ~= 'boolean' then
+        return true
+      end
+
+      return result
+    end, items)
+
+    ::skip_filter::
+  end
 
   local select_kind = string.format(
     'legendary.%s',

--- a/teal/legendary/filters.tl
+++ b/teal/legendary/filters.tl
@@ -1,0 +1,26 @@
+require('legendary.types')
+
+local M = {}
+
+function M.mode(mode: string): LegendaryItemFilter
+  return function(item: LegendaryItem): boolean
+    -- ignore everything but keymaps since they aren't tied to a mode
+    if not string.find(item.kind, 'keymap') then
+      return true
+    end
+
+    local keymap = item as LegendaryKeymap
+    local keymap_mode = keymap.mode or { 'n' }
+    if type(keymap_mode) == 'string' then
+      keymap_mode = { keymap_mode as string }
+    end
+
+    return vim.tbl_contains(keymap_mode as {string}, mode)
+  end
+end
+
+function M.current_mode(): LegendaryItemFilter
+  return M.mode((vim.fn.mode() or 'n') as string)
+end
+
+return M

--- a/teal/legendary/types.tl
+++ b/teal/legendary/types.tl
@@ -76,7 +76,10 @@ global record LegendaryItem
    id: integer
    kind: LegendaryKind
    description: string | nil
+   opts: table
 end
+
+global type LegendaryItemFilter = function(item: LegendaryItem): boolean
 
 global record LegendaryWhichKeys
    mappings: {table}

--- a/teal/vim.d.tl
+++ b/teal/vim.d.tl
@@ -106,8 +106,8 @@ global record vim
    tbl_deep_extend: function<T>(ExtendBehavior, {any:T}, {any:T}, ...: {any:T}): {any:T}
    tbl_deep_extend: function<T,V>(ExtendBehavior, {T:V}, {T:V}, ...: {T:V}): {T:V}
 
-   tbl_filter: function<T>(function(T): (boolean), {T})
-   tbl_filter: function(function(any): (boolean), {any})
+   tbl_filter: function<T>(function(T): (boolean), {T}): {T}
+   tbl_filter: function(function(any): (boolean), {any}): {any}
 
    tbl_flatten: function<T>({T|{T}}): {T}
    tbl_flatten: function({any|{any}}): {any}


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #129 

## How to Test

1. Call `require('legendary').find(nil, require('legendary.filters').mode('n'))`, it should only show normal mode mappings
2. Call `require('legendary').find(nil, require('legendary.filters').mode('i'))`, it should only show insert mode mappings

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly