### PR TITLE
Use package.searchers to make which-key integration not dependent on load order

### DIFF
--- a/lua/legendary/compat/which-key.lua
+++ b/lua/legendary/compat/which-key.lua
@@ -1,4 +1,4 @@
-local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local table = _tl_compat and _tl_compat.table or table; require('legendary.types')
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local package = _tl_compat and _tl_compat.package or package; local pcall = _tl_compat and _tl_compat.pcall or pcall; local table = _tl_compat and _tl_compat.table or table; require('legendary.types')
 local M = {}
 
 local function wk_to_legendary(wk, wk_opts)
@@ -65,15 +65,33 @@ end
 
 
 
-function M.whichkey_listen()
-   local wk = (_G['require']('which-key'))
-   local original = wk.register
-   local listener = function(whichkey_tbls, whichkey_opts)
-      M.bind_whichkey(whichkey_tbls, whichkey_opts, false)
-      original(whichkey_tbls, whichkey_opts)
+function M.whichkey_listen(halt)
+   local loaded, which_key = pcall(
+   _G['require'],
+   'which-key')
+
+
+   if loaded then
+      local wk = which_key
+      local original = wk.register
+      local listener = function(whichkey_tbls, whichkey_opts)
+         M.bind_whichkey(whichkey_tbls, whichkey_opts, false)
+         original(whichkey_tbls, whichkey_opts)
+      end
+      wk.register = listener
+      return true
+   elseif not halt then
+
+
+      local searcher = function(module)
+         if module == 'which-key' then
+            M.whichkey_listen(true)
+         end
+
+         return nil
+      end
+      table.insert(package.searchers, 1, searcher)
    end
-   wk.register = listener
-   return true
 end
 
 return M

--- a/teal/legendary/compat/which-key.tl
+++ b/teal/legendary/compat/which-key.tl
@@ -65,15 +65,33 @@ end
 
 --- Enable auto-registering of which-key.nvim tables
 --- with legendary.nvim
-function M.whichkey_listen(): boolean
-  local wk = (_G['require']('which-key') as table)
-  local original = wk.register as function(tbls: {table}, opts: table)
-  local listener = function(whichkey_tbls: {table}, whichkey_opts: table)
-    M.bind_whichkey(whichkey_tbls, whichkey_opts, false)
-    original(whichkey_tbls, whichkey_opts)
+function M.whichkey_listen(halt: boolean): boolean
+  local loaded, which_key = pcall(
+    _G['require'] as (function(module: string): table),
+    'which-key'
+  )
+
+  if loaded then
+    local wk = which_key as table
+    local original = wk.register as function(tbls: {table}, opts: table)
+    local listener = function(whichkey_tbls: {table}, whichkey_opts: table)
+      M.bind_whichkey(whichkey_tbls, whichkey_opts, false)
+      original(whichkey_tbls, whichkey_opts)
+    end
+    wk.register = listener
+    return true
+  elseif not halt then
+    -- if which-key is not loaded, set up package.searchers
+    -- to load the listener once which-key loads
+    local searcher = function(module: string): nil
+      if module == 'which-key' then
+        M.whichkey_listen(true)
+      end
+
+      return nil
+    end
+    table.insert(package.searchers, 1, searcher)
   end
-  wk.register = listener
-  return true
 end
 
 return M


### PR DESCRIPTION


<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #78  <!-- If this PR fixes an open issue, please link it here -->

## How to Test

1. Make sure `which-key` is loaded _after_ legendary
2. Setup which-key integration with `auto_load_which_key = true`
3. Make sure keymaps registered via which-key are picked up via legendary

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
