### PR TITLE
Remove print statement that was left in `bindings.tl`

### DIFF
--- a/lua/legendary/bindings.lua
+++ b/lua/legendary/bindings.lua
@@ -292,8 +292,6 @@ require('legendary.config').most_recent_item_at_top and
       return formatter.format(item, current_mode, opts.formatter)
    end
 
-   print(vim.inspect(format_item))
-
    vim.ui.select(items, {
       prompt = vim.trim((prompt) or ''),
       kind = select_kind,

--- a/teal/legendary/bindings.tl
+++ b/teal/legendary/bindings.tl
@@ -292,8 +292,6 @@ function M.find(opts: LegendaryFindOpts, _deprecated: any)
     return formatter.format(item, current_mode, opts.formatter)
   end
 
-  print(vim.inspect(format_item))
-
   vim.ui.select(items, {
     prompt = vim.trim((prompt as string | nil) or ''),
     kind = select_kind,


### PR DESCRIPTION
Removed this to prevent a `<function>1` from being displayed in `nvim`