### PR TITLE
feat: allow arbitrary Lua functions without mapping to a command 

### DIFF
--- a/doc/legendary-api.txt
+++ b/doc/legendary-api.txt
@@ -21,7 +21,7 @@ and parse them into legendary.nvim tables
 Parameters: ~
 {which_key_tbls}  (table[])
 {which_key_opts}  (table)
-{do_binding}      (boolean)   whether to bind the keymaps or let which-key handle i
+{do_binding}      (boolean)   whether to bind the keymaps or let which-key handle it
 
 Returns: ~
 {LegendaryItem[]}
@@ -34,7 +34,7 @@ Bind a which-key.nvim table with legendary.nvim
 Parameters: ~
 {wk_tbls}     (table)
 {wk_opts}     (table)
-{do_binding}  (boolean)   whether to bind the keymaps or let which-key handle i
+{do_binding}  (boolean)   whether to bind the keymaps or let which-key handle it
 
 
 M.whichkey_listen()                 *legendary.compat.which-key.whichkey_listen*
@@ -47,7 +47,7 @@ require('legendary.executor')                               *legendary.executor*
 
 *legendary.executor.try_execute*
 M.try_execute({item}, {current_buf}, {visual_selection}, {current_mode})
-Attmept to execute the selected item
+Attempt to execute the selected item
 
 Parameters: ~
 {item}              (LegendaryItem)
@@ -101,10 +101,12 @@ Default implementation of config.formatter
 Column one:
 - Keymaps => modes
 - Commands => '<cmd>'
+- Functions => '<function>'
 - Autocmds => events
 Column 2:
 - Keymaps => key codes
 - Commands => command
+- Functions => ''
 - Autocmds => patterns
 Column 3:
 - All => description
@@ -113,7 +115,7 @@ Parameters: ~
 {item}  (LegendaryItem)
 
 Returns: ~
-{table}  values to forma
+{table}  values to format
 
 
 M.get_format_values({item})              *legendary.formatter.get_format_values*
@@ -125,7 +127,7 @@ Parameters: ~
 {item}  (LegendaryItem)
 
 Returns: ~
-{table}  values to forma
+{table}  values to format
 
 
 M.update_padding({item})                    *legendary.formatter.update_padding*
@@ -173,7 +175,7 @@ Returns: ~
 M.lazy_required_fn({module_name}, {fn_name})  *legendary.helpers.lazy_required_fn*
 Given a Lua path to require, the name of a function in the `require`d module,
 and some arguments, return a new function that will call
-he function `fn_name` in module `module_name` with the specified args
+the function `fn_name` in module `module_name` with the specified args
 
 Parameters: ~
 {module_name}  (string)
@@ -185,7 +187,7 @@ Returns: ~
 
 M.split_then({fn})                                *legendary.helpers.split_then*
 Given a Lua function, return a new function
-hat will create a horizontal split before
+that will create a horizontal split before
 calling the specified function.
 
 Parameters: ~
@@ -197,7 +199,7 @@ Returns: ~
 
 M.vsplit_then({fn})                              *legendary.helpers.vsplit_then*
 Given a Lua function, return a new function
-hat will create a vertical split before
+that will create a vertical split before
 calling the specified function.
 
 Parameters: ~
@@ -254,11 +256,20 @@ A legendary command. You can add commands to the finder without binding them by 
 Fields: ~
 {[1]}          (string)
 {[2]}          (string)    | function | nil
-{mode}         (string)    | {string}
 {description}  (string)    | nil
 {opts}         (table)     | nil
 {kind}         (string)
 {unfinished}   (boolean)   | nil
+
+
+LegendaryFunction                                            *LegendaryFunction*
+A legendary function.
+
+Fields: ~
+{[1]}          (function)
+{description}  (string)     | nil
+{opts}         (table)      | nil
+{kind}         (string)
 
 
 LegendaryAutocmd                                              *LegendaryAutocmd*
@@ -291,6 +302,14 @@ Fields: ~
 
 LegendaryItemFilter                                        *LegendaryItemFilter*
 A type alias for
+
+
+LegendaryFormatter                                          *LegendaryFormatter*
+A type alias for
+
+
+Options                                                                *Options*
+accepted by `require('legendary').find()`
 
 
 LegendaryScratchpadDisplay                          *LegendaryScratchpadDisplay*
@@ -342,10 +361,17 @@ Parameters: ~
 
 M.validate_augroup({au})                      *legendary.types.validate_augroup*
 Validator function for LegendaryAugroups
-Note: does NOT validate the LegendaryAutocmds inside i
+Note: does NOT validate the LegendaryAutocmds inside it
 
 Parameters: ~
 {au}  (LegendaryAugroup)
+
+
+M.validate_function({au})                    *legendary.types.validate_function*
+Validator function for LegendaryFunctions
+
+Parameters: ~
+{au}  (LegendaryFunction)
 
 
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/legendary/cmds.lua
+++ b/lua/legendary/cmds.lua
@@ -32,6 +32,11 @@ M.cmds = {
             return
          end
 
+         if vim.trim((opts.args):lower()) == 'functions' then
+            require('legendary.bindings').find({ kind = 'legendary.function' })
+            return
+         end
+
          require('legendary.bindings').find()
       end,
       description = 'Find keymaps and commands with vim.ui.select()',
@@ -50,7 +55,11 @@ M.cmds = {
                return { 'autocmds' }
             end
 
-            return { 'keymaps', 'commands', 'autocmds' }
+            if arg_lead and vim.trim(arg_lead):sub(1, 1):lower() == 'f' then
+               return { 'functions' }
+            end
+
+            return { 'keymaps', 'commands', 'autocmds', 'functions' }
          end,
       },
    },

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -15,6 +15,7 @@ local M = {
    keymaps = {},
    commands = {},
    autocmds = {},
+   functions = {},
    which_key = {
       mappings = {},
       opts = {},
@@ -64,6 +65,7 @@ function M.setup(new_config)
    M.keymaps = (new_config.keymaps or M.keymaps)
    M.commands = (new_config.commands or M.commands)
    M.autocmds = (new_config.autocmds or M.autocmds)
+   M.functions = (new_config.functions or M.functions)
    M.which_key = default_whichkey(new_config.which_key)
    M.auto_register_which_key = default_bool(new_config.auto_register_which_key, M.auto_register_which_key)
    M.scratchpad = (new_config.scratchpad or M.scratchpad)

--- a/lua/legendary/formatter.lua
+++ b/lua/legendary/formatter.lua
@@ -19,6 +19,10 @@ function M.rpad(str, len)
 end
 
 local function col1_str(item)
+   if vim.startswith(item.kind or '', 'legendary.function') or type((item)[1]) == 'function' then
+      return '<function>'
+   end
+
    if vim.startswith(item.kind or '', 'legendary.command') then
       return '<cmd>'
    end
@@ -45,6 +49,10 @@ local function col1_str(item)
 end
 
 local function col2_str(item)
+   if vim.startswith(item.kind or '', 'legendary.function') or type((item)[1]) == 'function' then
+      return ''
+   end
+
    if vim.startswith(item.kind or '', 'legendary.autocmd') then
       local patterns = (item).opts and ((item).opts).pattern or '*'
       if type(patterns) == 'table' then
@@ -60,6 +68,8 @@ end
 local function col3_str(item)
    return item.description or ''
 end
+
+
 
 
 
@@ -100,12 +110,8 @@ function M.get_format_values(item, mode, one_shot_formatter)
       local values = formatter(item, mode)
 
       for i, value in ipairs(values) do
-         if value == nil then
-            values[i] = ''
-         end
-
          if type(value) ~= 'string' then
-            values[i] = tostring(value)
+            values[i] = tostring(value or '')
          end
       end
 

--- a/lua/legendary/init.lua
+++ b/lua/legendary/init.lua
@@ -58,6 +58,17 @@ M.bind_autocmds = b.bind_autocmds
 
 
 
+M.bind_function = b.bind_function
+
+
+
+
+M.bind_functions = b.bind_functions
+
+
+
+
+
 
 
 
@@ -101,6 +112,17 @@ M.setup = function(new_config)
 
    if config.autocmds and #config.autocmds > 0 then
       require('legendary.bindings').bind_autocmds(config.autocmds)
+   end
+
+   if config.functions and type(config.functions) ~= 'table' then
+      require('legendary.utils').notify(
+      string.format('functions must be a list-like table, got: %s', type(config.functions)))
+
+      return
+   end
+
+   if config.functions and #config.functions > 0 then
+      require('legendary.bindings').bind_functions(config.functions)
    end
 
    if config.which_key and config.which_key.mappings and #config.which_key.mappings > 0 then

--- a/lua/legendary/types.lua
+++ b/lua/legendary/types.lua
@@ -16,6 +16,7 @@ unpack = ((_G).unpack or _tl_table_unpack)
 
 
 
+
  LegendaryModeMappingOpts = {}
 
 
@@ -64,9 +65,21 @@ unpack = ((_G).unpack or _tl_table_unpack)
 
 
 
-
  LegendaryCommand = {}
 
+
+
+
+
+
+
+
+
+
+
+
+
+ LegendaryFunction = {}
 
 
 
@@ -173,6 +186,7 @@ unpack = ((_G).unpack or _tl_table_unpack)
 
 
 
+
 local M = {}
 
 
@@ -241,5 +255,18 @@ function M.validate_augroup(au)
       clear = { au.clear, 'boolean', true },
    })
 end
+
+
+
+function M.validate_function(command)
+   vim.validate({
+      ['1'] = { command[1], 'function' },
+      description = { command.description, 'string' },
+      opts = { command.opts, 'table', true },
+      kind = { command.kind, 'string' },
+      id = { command.id, 'number' },
+   })
+end
+
 
 return M

--- a/lua/legendary/utils.lua
+++ b/lua/legendary/utils.lua
@@ -307,6 +307,20 @@ end
 
 
 
+
+function M.is_user_function(cmd)
+   return not not (
+   cmd ~= nil and
+   type(cmd) == 'table' and
+   type(cmd[1]) == 'function' and
+   type(cmd.description) == 'string' and
+   cmd.description ~= '')
+
+end
+
+
+
+
 function M.is_user_command(cmd)
    return not not (
    cmd ~= nil and
@@ -381,6 +395,10 @@ end
 
 function M.get_definition(item, mode)
    mode = mode or vim.fn.mode()
+   if M.is_user_function(item) then
+      return item[1]
+   end
+
    if M.is_user_keymap(item) or M.is_user_autocmd(item) then
       local def = (item)[2]
 

--- a/teal/legendary/bindings.tl
+++ b/teal/legendary/bindings.tl
@@ -12,6 +12,7 @@ local last_used_item: LegendaryItem
 local keymaps = require('legendary.config').keymaps
 local commands = require('legendary.config').commands
 local autocmds = require('legendary.config').autocmds
+local functions = require('legendary.config').functions
 
 local utils = require('legendary.utils')
 
@@ -195,6 +196,50 @@ function M.bind_autocmds(au: table, kind: string | nil)
   end
 end
 
+--- Bind a single function with legendary.nvim
+---@param fn LegendaryFunction
+function M.bind_function(fn: LegendaryFunction, kind: string | nil)
+  fn = utils.resolve_description(fn)
+  fn.kind = (kind or 'legendary.function') as LegendaryKind
+  fn.id = next_id()
+  types.validate_function(fn)
+
+  if not fn or type(fn) ~= 'table' then
+    utils.notify(string.format('Expected table, got %s', type(fn)))
+    return
+  end
+
+  if fn.opts and fn.opts.buffer == 0 then
+    fn.opts.buffer = vim.api.nvim_get_current_buf()
+  end
+
+  if utils.list_contains(functions, fn) then
+    return
+  end
+
+  require('legendary.formatter').update_padding(fn as LegendaryItem)
+  table.insert(functions, fn)
+end
+
+--- Bind a list of functions with legendary.nvim
+---@param fns LegendaryFunction[]
+function M.bind_functions(fns: {LegendaryFunction}, kind: string | nil)
+  if not fns or type(fns) ~= 'table' then
+    return
+  end
+
+  if not vim.tbl_islist(fns) then
+    utils.notify(
+      string.format('Expected list-like table, got %s, at require("legendary").bind_commands', type(fns))
+    )
+    return
+  end
+
+  vim.tbl_map(function(fn: LegendaryFunction): nil
+    M.bind_function(fn, kind)
+  end, fns)
+end
+
 --- Find keymaps, commands, or both (both by default)
 --- with legendary.nvim. To find only keymaps, pass
 --- "keymaps" as a parameter, pass "commands" to find
@@ -225,10 +270,13 @@ function M.find(opts: LegendaryFindOpts, _deprecated: any)
     items = commands as {LegendaryItem}
   elseif string.find(item_kind, 'autocmd') then
     items = autocmds as {LegendaryItem}
+  elseif item_kind == 'legendary.function' then
+    items = functions as {LegendaryItem}
   else
     items = vim.list_extend({}, keymaps as {LegendaryItem})
     items = vim.list_extend(items, commands as {LegendaryItem})
     items = vim.list_extend(items, autocmds as {LegendaryItem})
+    items = vim.list_extend(items, functions as {LegendaryItem})
   end
 
 

--- a/teal/legendary/cmds.tl
+++ b/teal/legendary/cmds.tl
@@ -32,6 +32,11 @@ M.cmds = {
         return
       end
 
+      if vim.trim((opts.args as string):lower()) == 'functions' then
+        require('legendary.bindings').find({ kind = 'legendary.function' })
+        return
+      end
+
       require('legendary.bindings').find()
     end,
     description = 'Find keymaps and commands with vim.ui.select()',
@@ -50,7 +55,11 @@ M.cmds = {
           return { 'autocmds' }
         end
 
-        return { 'keymaps', 'commands', 'autocmds' }
+        if arg_lead and vim.trim(arg_lead):sub(1, 1):lower() == 'f' then
+          return { 'functions' }
+        end
+
+        return { 'keymaps', 'commands', 'autocmds', 'functions' }
       end,
     },
   },

--- a/teal/legendary/config.tl
+++ b/teal/legendary/config.tl
@@ -15,6 +15,7 @@ local M: LegendaryConfig = {
   keymaps = {},
   commands = {},
   autocmds = {},
+  functions = {},
   which_key = {
     mappings = {},
     opts = {},
@@ -64,6 +65,7 @@ function M.setup(new_config: table): LegendaryConfig
   M.keymaps = (new_config.keymaps or M.keymaps) as {LegendaryKeymap}
   M.commands = (new_config.commands or M.commands) as {LegendaryCommand}
   M.autocmds = (new_config.autocmds or M.autocmds) as {LegendaryAugroup}
+  M.functions = (new_config.functions or M.functions) as {LegendaryFunction}
   M.which_key = default_whichkey(new_config.which_key as table)
   M.auto_register_which_key = default_bool(new_config.auto_register_which_key as boolean | nil, M.auto_register_which_key)
   M.scratchpad = (new_config.scratchpad or M.scratchpad) as LegendaryScratchpadConfig

--- a/teal/legendary/executor.tl
+++ b/teal/legendary/executor.tl
@@ -57,7 +57,7 @@ local function exec(item: LegendaryItem, mode: string, visual_selection: table)
   end
 end
 
---- Attmept to execute the selected item
+--- Attempt to execute the selected item
 ---@param item LegendaryItem
 ---@param current_buf integer
 ---@param visual_selection table | nil, { row, col, row, col }

--- a/teal/legendary/formatter.tl
+++ b/teal/legendary/formatter.tl
@@ -19,6 +19,10 @@ function M.rpad(str: string, len: integer): string
 end
 
 local function col1_str(item: LegendaryItem): string
+  if vim.startswith(item.kind or '', 'legendary.function') or type((item as table)[1]) == 'function' then
+    return '<function>'
+  end
+
   if vim.startswith(item.kind or '', 'legendary.command') then
     return '<cmd>'
   end
@@ -45,6 +49,10 @@ local function col1_str(item: LegendaryItem): string
 end
 
 local function col2_str(item: LegendaryItem): string
+  if vim.startswith(item.kind or '', 'legendary.function') or type((item as table)[1]) == 'function' then
+    return ''
+  end
+
   if vim.startswith(item.kind or '', 'legendary.autocmd') then
     local patterns = (item as table).opts and ((item as table).opts as table).pattern or '*'
     if type(patterns) == 'table' then
@@ -65,10 +73,12 @@ end
 --- Column one:
 ---   - Keymaps => modes
 ---   - Commands => '<cmd>'
+---   - Functions => '<function>'
 ---   - Autocmds => events
 --- Column 2:
 ---   - Keymaps => key codes
 ---   - Commands => command
+---   - Functions => ''
 ---   - Autocmds => patterns
 --- Column 3:
 ---   - All => description
@@ -100,12 +110,8 @@ function M.get_format_values(item: LegendaryItem, mode: string, one_shot_formatt
     local values = formatter(item, mode)
     -- normalize values
     for i, value in ipairs(values) do
-      if value == nil then
-        values[i] = ''
-      end
-
       if type(value) ~= 'string' then
-        values[i] = tostring(value)
+        values[i] = tostring(value or '')
       end
     end
 

--- a/teal/legendary/init.tl
+++ b/teal/legendary/init.tl
@@ -55,11 +55,22 @@ M.bind_commands = b.bind_commands
 ---@param au LegendaryAugroup[] | LegendaryItem[]
 M.bind_autocmds = b.bind_autocmds
 
+--- Alias to `require('legendary.bindings').bind_function`
+--- Bind a single function with legendary.nvim
+---@param function LegendaryFunction
+M.bind_function = b.bind_function
+
+--- Alias to `require('legendary.bindings').bind_functions`
+--- Bind a list of functions with legendary.nvim
+---@param functions LegendaryFunctions[]
+M.bind_functions = b.bind_functions
+
 --- Alias to `require('legendary.bindings).find`
 --- Find keymaps, commands, or both (both by default)
 --- with legendary.nvim. To find only keymaps, pass
 --- "keymaps" as a parameter, pass "commands" to find
---- only commands, pass "autocmds" to find only autocmds.
+--- only commands, pass "autocmds" to find only autocmds,
+--- pass 'functions' to find only functions.
 ---@param item_kind string | nil
 ---@param filters {LegendaryItemFilter} | nil
 M.find = b.find
@@ -101,6 +112,17 @@ M.setup = function(new_config: table)
 
   if config.autocmds and #config.autocmds > 0 then
     require('legendary.bindings').bind_autocmds(config.autocmds)
+  end
+
+  if config.functions and type(config.functions) ~= 'table' then
+    require('legendary.utils').notify(
+      string.format('functions must be a list-like table, got: %s', type(config.functions))
+    )
+    return
+  end
+
+  if config.functions and #config.functions > 0 then
+    require('legendary.bindings').bind_functions(config.functions)
   end
 
   if config.which_key and config.which_key.mappings and #config.which_key.mappings > 0 then

--- a/teal/legendary/types.tl
+++ b/teal/legendary/types.tl
@@ -11,6 +11,7 @@ global enum LegendaryKind
    'legendary.command.builtin'
    'legendary.augroup'
    'legendary.autocmd'
+   'legendary.function'
 end
 
 ---@class LegendaryModeMappingOpts The value of a per-mode mapping with per-mode opts
@@ -60,7 +61,6 @@ end
 ---@class LegendaryCommand A legendary command. You can add commands to the finder without binding them by omitting the second list element.
 ---@field [1] string
 ---@field [2] string | function | nil
----@field mode string | {string}
 ---@field description string | nil
 ---@field opts table | nil
 ---@field kind string
@@ -72,6 +72,19 @@ global record LegendaryCommand
    kind: LegendaryKind
    id: integer
    unfinished: boolean | nil
+end
+
+---@class LegendaryFunction A legendary function.
+---@field [1] function
+---@field description string | nil
+---@field opts table | nil
+---@field kind string
+global record LegendaryFunction
+   {function}
+   description: string
+   opts: {string: any}
+   kind: LegendaryKind
+   id: integer
 end
 
 ---@class LegendaryAutocmd A legendary autocmd
@@ -167,6 +180,7 @@ global record LegendaryConfig
    keymaps: {LegendaryKeymap}
    commands: {LegendaryCommand}
    autocmds: {LegendaryAugroup}
+   functions: {LegendaryFunction}
    auto_register_which_key: boolean
    which_key: LegendaryWhichKeys
    scratchpad: LegendaryScratchpadConfig
@@ -241,5 +255,18 @@ function M.validate_augroup(au: LegendaryAugroup)
    clear = { au.clear, 'boolean', true },
  })
 end
+
+--- Validator function for LegendaryFunctions
+---@param au LegendaryFunction
+function M.validate_function(command: LegendaryFunction)
+   vim.validate({
+      ['1'] = { command[1], 'function' },
+      description = { command.description, 'string' },
+      opts = { command.opts, 'table', true },
+      kind = { command.kind, 'string' },
+      id = { command.id, 'number' },
+   })
+end
+
 
 return M

--- a/teal/legendary/utils.tl
+++ b/teal/legendary/utils.tl
@@ -304,6 +304,20 @@ function M.append_trailing_cr(cmd_str: string): string
   return cmd
 end
 
+
+--- Check if given item is a user-defined function
+---@param cmd any
+---@return boolean
+function M.is_user_function(cmd: LegendaryFunction): boolean
+  return not not (
+      cmd ~= nil
+      and type(cmd) == 'table'
+      and type(cmd[1]) == 'function'
+      and type(cmd.description) == 'string'
+      and cmd.description ~= ''
+    )
+end
+
 --- Check if given item is a user-defined command
 ---@param cmd any
 ---@return boolean
@@ -381,6 +395,10 @@ end
 ---@return string | function
 function M.get_definition(item: table, mode: string | nil): string | function(marks: table): nil
   mode = mode or vim.fn.mode() as string
+  if M.is_user_function(item as LegendaryFunction) then
+    return item[1] as function(marks: table): nil
+  end
+
   if M.is_user_keymap(item as LegendaryKeymap) or M.is_user_autocmd(item as LegendaryAutocmd) then
     local def = (item as table)[2]
     -- if it's a per-mode mapping,


### PR DESCRIPTION
Resolves: #149 <!-- If this PR fixes an open issue, please link it here -->

## How to Test

Create/bind a function such as 
```lua
require("legendary.bindings").bind_functions({
  {
    function(args)
      if args then vim.pretty_print(args) end

      vim.lsp.buf.code_action({
        filter = function(a)
          return a.isPreferred
        end,
        apply = true,
      })
    end,
    description = "Auto Fix...",
    opts = { buffer = bufnr },
  },
}, "LSP")
```

Check that it's displayed in the menu and correctly called. Further, if `opts.buffer` is set, then it should be available only for the specified buffer. If you're in visual mode, the function above should also print the selection range.

## Testing for Regressions

- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)

----------

I'll write proper commit messages later.