### PR TITLE
dynamically compute padding on the fly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+default: build
+
 .PHONY: ensure-test-deps
 ensure-test-deps:
 	@mkdir -p vendor

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The `require('legend').find()` function takes an `opts` table with the following
   -- `require('legendary.filters').mode(mode)` and `require('legendary.filters').current_mode()`
   -- are provided for convenience
   filters = {},
-  -- pass a function with the signature `function(item): {string}`
+  -- pass a function with the signature `function(item, mode): {string}`
   -- returning a list of strings where each string is one column
   -- use this to override the configured formatter for just one call
   formatter = nil,
@@ -115,7 +115,7 @@ require('legendary').find({
   filters = { require('legendary.filters').current_mode() },
   formatter = function(item, mode)
     local values = require('legendary.formatter').get_default_format_values(item)
-    if string.find(item.kind 'keymap') then
+    if string.find(item.kind, 'keymap') then
       values[1] = mode
     end
     return values

--- a/lua/legendary/bindings.lua
+++ b/lua/legendary/bindings.lua
@@ -40,7 +40,6 @@ function M.bind_keymap(keymap, kind)
    end
 
    utils.set_keymap(keymap)
-   formatter.update_padding(keymap)
    for _, resolved_keymap in ipairs(utils.resolve_with_per_mode_description(keymap)) do
       keymap.id = next_id()
       table.insert(keymaps, resolved_keymap)
@@ -87,7 +86,6 @@ function M.bind_command(cmd, kind)
    end
 
    utils.set_command(cmd)
-   formatter.update_padding(cmd)
    table.insert(commands, cmd)
 end
 
@@ -140,7 +138,6 @@ local function bind_autocmd(autocmd, group, kind)
 
    utils.set_autocmd(autocmd, group)
    if autocmd.description and #autocmd.description > 0 and not (autocmd.opts or {}).once then
-      formatter.update_padding(autocmd)
       table.insert(autocmds, autocmd)
    end
 end
@@ -217,7 +214,6 @@ function M.bind_function(fn, kind)
       return
    end
 
-   require('legendary.formatter').update_padding(fn)
    table.insert(functions, fn)
 end
 
@@ -336,8 +332,9 @@ require('legendary.config').most_recent_item_at_top and
       prompt = (prompt)(select_kind)
    end
 
+   local padding = formatter.compute_padding(items, current_mode, opts.formatter)
    local format_item = function(item)
-      return formatter.format(item, current_mode, opts.formatter)
+      return formatter.format(item, current_mode, padding, opts.formatter)
    end
 
    vim.ui.select(items, {

--- a/lua/legendary/formatter.lua
+++ b/lua/legendary/formatter.lua
@@ -3,13 +3,6 @@ local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 th
 require('legendary.types')
 local M = {}
 
-local padding = {}
-
-
-function M.__clear_padding()
-   padding = {}
-end
-
 
 
 
@@ -123,29 +116,28 @@ end
 
 
 
-function M.update_padding(item)
-   local values = M.get_format_values(item)
-   for i, value in ipairs(values) do
-      local len = vim.fn.strdisplaywidth(value)
-      if len > (padding[i] or 0) then
-         padding[i] = len
+
+
+
+function M.compute_padding(items, mode, formatter)
+   local padding = {}
+   for _, item in ipairs(items) do
+      local values = M.get_format_values(item, mode, formatter)
+      for i, value in ipairs(values) do
+         local len = vim.fn.strdisplaywidth(value)
+         if len > (padding[i] or 0) then
+            padding[i] = len
+         end
       end
    end
+
+   return padding
 end
 
 
 
 
-
-
-function M.get_padding()
-   return vim.deepcopy(padding)
-end
-
-
-
-
-function M.format(item, mode, formatter)
+function M.format(item, mode, padding, formatter)
    local values = M.get_format_values(item, mode, formatter)
 
    local strs = {}

--- a/teal/legendary/bindings.tl
+++ b/teal/legendary/bindings.tl
@@ -40,7 +40,6 @@ function M.bind_keymap(keymap: LegendaryKeymap, kind: string | nil)
   end
 
   utils.set_keymap(keymap)
-  formatter.update_padding(keymap as LegendaryItem)
   for _, resolved_keymap in ipairs(utils.resolve_with_per_mode_description(keymap)) do
     keymap.id = next_id()
     table.insert(keymaps, resolved_keymap)
@@ -87,7 +86,6 @@ function M.bind_command(cmd: LegendaryCommand, kind: string | nil)
   end
 
   utils.set_command(cmd)
-  formatter.update_padding(cmd as LegendaryItem)
   table.insert(commands, cmd)
 end
 
@@ -140,7 +138,6 @@ local function bind_autocmd(autocmd: LegendaryAutocmd, group: string | nil, kind
 
   utils.set_autocmd(autocmd, group)
   if autocmd.description and #autocmd.description > 0 and not (autocmd.opts or {}).once then
-    formatter.update_padding(autocmd as LegendaryItem)
     table.insert(autocmds as {LegendaryAutocmd}, autocmd)
   end
 end
@@ -217,7 +214,6 @@ function M.bind_function(fn: LegendaryFunction, kind: string | nil)
     return
   end
 
-  require('legendary.formatter').update_padding(fn as LegendaryItem)
   table.insert(functions, fn)
 end
 
@@ -336,8 +332,9 @@ function M.find(opts: LegendaryFindOpts, _deprecated: any)
     prompt = (prompt as function(kind: string): string)(select_kind)
   end
 
+  local padding = formatter.compute_padding(items, current_mode, opts.formatter)
   local format_item = function(item: LegendaryItem): string
-    return formatter.format(item, current_mode, opts.formatter)
+    return formatter.format(item, current_mode, padding, opts.formatter)
   end
 
   vim.ui.select(items, {

--- a/teal/legendary/formatter.tl
+++ b/teal/legendary/formatter.tl
@@ -3,13 +3,6 @@
 require('legendary.types')
 local M = {}
 
-local padding: {integer} = {}
-
---- for unit tests only, should not be called from plugin code!
-function M.__clear_padding()
-  padding = {}
-end
-
 ---Right-pad strings to specified length
 ---@param str string the string to pad
 ---@param len integer the padding value to use
@@ -121,31 +114,30 @@ function M.get_format_values(item: LegendaryItem, mode: string, one_shot_formatt
   return M.get_default_format_values(item)
 end
 
---- Update cached column paddings.
----@param item LegendaryItem
-function M.update_padding(item: LegendaryItem)
-  local values = M.get_format_values(item)
-  for i, value in ipairs(values) do
-    local len = vim.fn.strdisplaywidth(value) as integer
-    if len > (padding[i] or 0) then
-      padding[i] = len
+---Compute padding values given items, mode, and formatter
+---@param items {LegendaryItem} the items being searched
+---@param mode string current mode
+---@mode formatter LegendaryFormatter|nil the formatter to use, or nil for default
+---@returns {integer}
+function M.compute_padding(items: {LegendaryItem}, mode: string, formatter: LegendaryFormatter | nil): {integer}
+  local padding: {integer} = {}
+  for _, item in ipairs(items) do
+    local values = M.get_format_values(item, mode, formatter)
+    for i, value in ipairs(values) do
+      local len = vim.fn.strdisplaywidth(value) as integer
+      if len > (padding[i] or 0) then
+        padding[i] = len
+      end
     end
   end
-end
 
---- Returns a READ-ONLY COPY of the current padding values.
---- Note that this is a COPY of the table so it will not update,
---- and writing to it will not do anything. Padding is managed
---- internally by the formatter and should not be modified manually.
----@return table a table containing the padding value for each column.
-function M.get_padding(): {integer}
-  return vim.deepcopy(padding)
+  return padding
 end
 
 --- Format a LegendaryItem to a string
 ---@param item LegendaryItem
 ---@return string
-function M.format(item: LegendaryItem, mode: string, formatter: LegendaryFormatter | nil): string
+function M.format(item: LegendaryItem, mode: string, padding: {integer}, formatter: LegendaryFormatter | nil): string
   local values = M.get_format_values(item, mode, formatter)
 
   local strs = {}

--- a/tests/legendary/formatter_spec.lua
+++ b/tests/legendary/formatter_spec.lua
@@ -74,7 +74,7 @@ describe('formatter', function()
         formatter.update_padding(item)
       end, items)
 
-      local padding = formatter.get_padding()
+      local padding = formatter.compute_padding(items, 'n')
       assert.are.same(#padding, 3)
       assert.are.same(padding[1], #'<leader>c')
       assert.are.same(padding[2], #'lua vim.lsp.buf.definition')
@@ -100,7 +100,7 @@ describe('formatter', function()
         formatter.update_padding(item)
       end, items)
 
-      local padding = formatter.get_padding()
+      local padding = formatter.compute_padding(items, 'n')
       assert.are.same(#padding, 1)
       assert.are.same(padding[1], 1)
     end)
@@ -132,7 +132,7 @@ describe('formatter', function()
         end, items)
 
         local padded = {}
-        local padding = formatter.get_padding()
+        local padding = formatter.compute_padding(items, 'n')
         vim.tbl_map(function(item)
           table.insert(padded, {
             formatter.rpad(item[1], padding[1]),


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #161 

Also: Resolves: #153 

## How to Test

With the following config, columns should be aligned:

```lua
local legendary = require('legendary')
local filters = require('legendary.filters')

legendary.bind_commands({
    { ':Mason',  description = '查看lsp/dap包管理器窗口' },
    { ':MasonInstall',  unfinished = true, description = '安装或重新安装lsp/dap包'},
    { ':MasonUninstall',  unfinished = true, description = '卸载lsp/dap包'},
    { ':MasonUninstallAll',  description = '卸载所有lsp/dap包'},
    { ':MasonLog',  description = '在一个新tab页中打开mason.nvim的日志文件'},
})
legendary.bind_commands({
    { ':LspInstall',  unfinished = true, description = '安装或重新安装lsp包(lspconfig名称格式)' },
    { ':LspUninstall',  unfinished = true, description ='卸载lsp包(lspconfig名称格式)' },
})

legendary.find({
  --TODO find命令里应该也可以修改select_prompt
  filters = {
      --只显示当前模式的映射
      filters.current_mode(),

      --只显示映射和命令,不显示autocmd
      function(item)
          if string.find(item.kind, 'keymap') then
              return true
          end
          if string.find(item.kind, 'command') then
              return true
          end
          return false
      end,
  },

  --TODO kind选项的工作也可以交给formatter选项了
  --TODO 为不同类型的条目显示不同的颜色或图标
  --不显示第一列的映射模式或<cmd>
  --支持给条目添加标签,但是不显示在条目的描述内容中,但在搜索时会匹配标签内容
  formatter = function(item, mode)
      local values = require('legendary.formatter').get_default_format_values(item)
      values[1] = nil
      return values
  end
})
```

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
