### PR TITLE
allow passing `select_prompt` for one-shot finds

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ The `require('legend').find()` function takes an `opts` table with the following
   -- returning a list of strings where each string is one column
   -- use this to override the configured formatter for just one call
   formatter = nil,
+  -- pass a string, or a function with the signature `function(kind: string): string`
+  -- to customize the select prompt for the current call
+  select_prompt = nil,
 }
 ```
 
@@ -97,6 +100,14 @@ require('legendary').find({ filters = require('legendary.filters').current_mode(
 require('legendary').find({ filters = require('legendary.filters').mode('n') })
 -- show only keymaps and filter by normal mode
 require('legendary').find({ kind = 'keymaps', filters = require('legendary.filters').mode('n') })
+-- customize the select prompt
+require('legendary').find({ select_prompt = 'Custom prompt' })
+require('legendary').find({
+  kind = 'keymaps',
+  select_prompt = function(kind)
+    return string.format('Finding %s', kind)
+  end
+})
 -- filter keymaps by normal mode and that start with <leader>
 require('legendary').find({
   filters = {

--- a/lua/legendary/bindings.lua
+++ b/lua/legendary/bindings.lua
@@ -327,7 +327,7 @@ require('legendary.config').most_recent_item_at_top and
    'legendary.%s',
    type(item_kind) == 'string' and #item_kind > 0 and item_kind or 'items')
 
-   local prompt = require('legendary.config').select_prompt
+   local prompt = opts.select_prompt or require('legendary.config').select_prompt
    if type(prompt) == 'function' then
       prompt = (prompt)(select_kind)
    end

--- a/lua/legendary/filters.lua
+++ b/lua/legendary/filters.lua
@@ -29,7 +29,6 @@ end
 
 
 function M.current_mode()
-   print(vim.fn.mode())
    return M.mode((vim.fn.mode() or 'n'))
 end
 

--- a/lua/legendary/types.lua
+++ b/lua/legendary/types.lua
@@ -135,7 +135,9 @@ unpack = ((_G).unpack or _tl_table_unpack)
 
 
 
+
  LegendaryFindOpts = {}
+
 
 
 

--- a/teal/legendary/bindings.tl
+++ b/teal/legendary/bindings.tl
@@ -327,7 +327,7 @@ function M.find(opts: LegendaryFindOpts, _deprecated: any)
     'legendary.%s',
     type(item_kind) == 'string' and #item_kind > 0 and item_kind or 'items'
   )
-  local prompt = require('legendary.config').select_prompt
+  local prompt = opts.select_prompt or require('legendary.config').select_prompt
   if type(prompt) == 'function' then
     prompt = (prompt as function(kind: string): string)(select_kind)
   end

--- a/teal/legendary/filters.tl
+++ b/teal/legendary/filters.tl
@@ -29,7 +29,6 @@ end
 --- by the current mode
 ---@return LegendaryItemFilter
 function M.current_mode(): LegendaryItemFilter
-print(vim.fn.mode())
   return M.mode((vim.fn.mode() or 'n') as string)
 end
 

--- a/teal/legendary/types.tl
+++ b/teal/legendary/types.tl
@@ -135,10 +135,12 @@ global type LegendaryFormatter = function(LegendaryItem, string): {string}
 ---@field kind 'keymaps' | 'commands' | 'autocmds' | nil
 ---@field filters {LegendaryItemFilter} | nil
 ---@field formatter LegendaryFormatter | nil
+---@field select_prompt nil | string | function(string): string
 global record LegendaryFindOpts
    kind: string | nil
    filters: {LegendaryItemFilter} | nil
    formatter: LegendaryFormatter
+   select_prompt: nil | string | function(string): string
 end
 
 global record LegendaryWhichKeys


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #160  <!-- If this PR fixes an open issue, please link it here -->

## How to Test

1. Pass `select_prompt` option to find function.

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
