### PR TITLE
Mrj/166/fix lazy required fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,9 @@ you can use the following helper functions:
 local helpers = require('legendary.helpers')
 local keymaps = {
   { '<leader>p', helpers.lazy(vim.lsp.buf.formatting_sync, nil, 1500), description = 'Format with 1.5s timeout' },
-  { '<leader>f', helpers.lazy_required_fn('telescope.builtin', 'oldfiles', { only_cwd = true }) }
+  { '<leader>f', helpers.lazy_required_fn('telescope.builtin', 'oldfiles', { only_cwd = true }) },
+  -- you can use a dot in the 2nd parameter to access functions nested in tables
+  { '<leader>tt', helpers.lazy_required_fn('neotest', 'run.run') },
 }
 ```
 
@@ -743,6 +745,16 @@ require('legendary.helpers').lazy_required_fn('telescope.builtin', 'oldfiles', {
 -- this will *return a new function* defined as:
 function()
   require('telescope.bulitin')['oldfiles']({ only_cwd = true })
+end
+```
+
+You can also use dots to access functions that are nested within tables, for example with Neotest:
+
+```lua
+require('legendary.helpers').lazy_required_fn('neotest', 'run.run')
+-- this will *return a new function* defined as:
+function()
+  require('neotest')['run']['run']()
 end
 ```
 

--- a/lua/legendary/helpers.lua
+++ b/lua/legendary/helpers.lua
@@ -1,4 +1,4 @@
-
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local string = _tl_compat and _tl_compat.string or string
 
 require('legendary.types')
 local M = {}
@@ -15,6 +15,19 @@ function M.lazy(fn, ...)
    end
 end
 
+local function is_function(a)
+   if type(a) == 'function' then
+      return true
+   end
+
+   local mt = getmetatable(a)
+   if not mt then
+      return false
+   end
+
+   return not not mt.__call
+end
+
 
 
 
@@ -24,7 +37,26 @@ end
 function M.lazy_required_fn(module_name, fn_name, ...)
    local args = { ... }
    return function()
-      ((_G['require'](module_name))[fn_name])(unpack(args))
+      local module = (_G['require'](module_name))
+      if string.find(fn_name, '%.') then
+         local fn = module
+         for _, key in ipairs(vim.split(fn_name, '%.')) do
+            fn = (fn)[key]
+            if fn == nil then
+               vim.notify('[legendary.nvim]: invalid lazy_required_fn usage: no such function path')
+               return
+            end
+         end
+         if not is_function(fn) then
+            vim.notify('[legendary.nvim]: invalid lazy_required_fn usage: no such function path')
+            return
+         end
+         local final_fn = fn
+         final_fn(unpack(args))
+      else
+         local fn = module[fn_name]
+         fn(unpack(args))
+      end
    end
 end
 

--- a/teal/legendary/helpers.tl
+++ b/teal/legendary/helpers.tl
@@ -15,6 +15,19 @@ function M.lazy(fn: function(...: any), ...: any): function()
   end
 end
 
+local function is_function(a: any): boolean
+  if type(a) == 'function' then
+    return true
+  end
+
+  local mt = getmetatable(a)
+  if not mt then
+    return false
+  end
+
+  return not not mt.__call
+end
+
 --- Given a Lua path to require, the name of a function in the `require`d module,
 --- and some arguments, return a new function that will call
 --- the function `fn_name` in module `module_name` with the specified args
@@ -24,7 +37,26 @@ end
 function M.lazy_required_fn(module_name: string, fn_name: string, ...: any): function()
   local args = { ... }
   return function()
-    ((_G['require'](module_name) as table)[fn_name] as function(...: any))(unpack(args))
+    local module = (_G['require'](module_name) as table)
+    if string.find(fn_name, '%.') then
+      local fn: any = module
+      for _, key in ipairs(vim.split(fn_name, '%.')) do
+        fn = (fn as table)[key]
+        if fn == nil then
+          vim.notify('[legendary.nvim]: invalid lazy_required_fn usage: no such function path')
+          return
+        end
+      end
+      if not is_function(fn) then
+        vim.notify('[legendary.nvim]: invalid lazy_required_fn usage: no such function path')
+        return
+      end
+      local final_fn = fn as function
+      final_fn(unpack(args))
+    else
+      local fn = module[fn_name] as function
+      fn(unpack(args))
+    end
   end
 end
 

--- a/teal/vim.d.tl
+++ b/teal/vim.d.tl
@@ -109,7 +109,7 @@ global record vim
    tbl_filter: function<T>(function(T): (boolean), {T}): {T}
    tbl_filter: function(function(any): (boolean), {any}): {any}
 
-   tbl_get: function(table, ...: string | integer): any
+   tbl_get: function(any, ...: any): any
 
    tbl_flatten: function<T>({T|{T}}): {T}
    tbl_flatten: function({any|{any}}): {any}

--- a/teal/vim.d.tl
+++ b/teal/vim.d.tl
@@ -109,6 +109,8 @@ global record vim
    tbl_filter: function<T>(function(T): (boolean), {T}): {T}
    tbl_filter: function(function(any): (boolean), {any}): {any}
 
+   tbl_get: function(table, ...: string | integer): any
+
    tbl_flatten: function<T>({T|{T}}): {T}
    tbl_flatten: function({any|{any}}): {any}
 
@@ -874,8 +876,11 @@ global record vim
       mousefocus: boolean
       mousehide: boolean
       mousem: string
+      mousemev: boolean
       mousemodel: string
+      mousemoveevent: boolean
       mouses: string
+      mousescroll: string
       mouseshape: string
       mouset: number
       mousetime: number
@@ -1158,6 +1163,7 @@ global record vim
       wak: string
       warn: boolean
       wb: boolean
+      wbr: string
       wc: number
       wcm: number
       wd: number
@@ -1177,6 +1183,7 @@ global record vim
       wildoptions: string
       wim: string
       winaltkeys: string
+      winbar: string
       winbl: number
       winblend: number
       window: number
@@ -1429,8 +1436,11 @@ global record vim
       mousefocus: boolean
       mousehide: boolean
       mousem: string
+      mousemev: boolean
       mousemodel: string
+      mousemoveevent: boolean
       mouses: string
+      mousescroll: string
       mouseshape: string
       mouset: number
       mousetime: number
@@ -1904,8 +1914,10 @@ global record vim
       stl: string
       ve: string
       virtualedit: string
+      wbr: string
       wfh: boolean
       wfw: boolean
+      winbar: string
       winbl: number
       winblend: number
       winfixheight: boolean
@@ -1919,11 +1931,11 @@ global record vim
    record api
       --[[
          API version Information
-            neovim version: 0.7.0
+            neovim version: 0.8.0
 
             compatible: 0
-            level: 9
-            prerelease: true
+            level: 10
+            prerelease: false
       --]]
 
       --[[
@@ -1980,6 +1992,7 @@ global record vim
       nvim_call_function: function(string--[[String]], any--[[Array]]): any--[[Object]]
       nvim_chan_send: function(integer--[[Integer]], string--[[String]])--[[void]]
       nvim_clear_autocmds: function({string:any}--[[Dictionary]])--[[void]]
+      nvim_cmd: function({string:any}--[[Dictionary]], {string:any}--[[Dictionary]]): string--[[String]]
       nvim_command: function(string--[[String]])--[[void]]
       nvim_create_augroup: function(string--[[String]], {string:any}--[[Dictionary]]): integer--[[Integer]]
       nvim_create_autocmd: function(any--[[Object]], {string:any}--[[Dictionary]]): integer--[[Integer]]
@@ -2043,6 +2056,7 @@ global record vim
       nvim_open_term: function(integer--[[Buffer]], {string:any}--[[Dictionary]]): integer--[[Integer]]
       nvim_open_win: function(integer--[[Buffer]], boolean--[[Boolean]], {string:any}--[[Dictionary]]): integer--[[Window]]
       nvim_out_write: function(string--[[String]])--[[void]]
+      nvim_parse_cmd: function(string--[[String]], {string:any}--[[Dictionary]]): {string:any}--[[Dictionary]]
       nvim_parse_expression: function(string--[[String]], string--[[String]], boolean--[[Boolean]]): {string:any}--[[Dictionary]]
       nvim_paste: function(string--[[String]], boolean--[[Boolean]], integer--[[Integer]]): boolean--[[Boolean]]
       nvim_put: function({string}--[[ArrayOf(String)]], string--[[String]], boolean--[[Boolean]], boolean--[[Boolean]])--[[void]]
@@ -2056,6 +2070,8 @@ global record vim
       nvim_set_current_win: function(integer--[[Window]])--[[void]]
       nvim_set_decoration_provider: function(integer--[[Integer]], {string:any}--[[Dictionary]])--[[void]]
       nvim_set_hl: function(integer--[[Integer]], string--[[String]], {string:any}--[[Dictionary]])--[[void]]
+      nvim_set_hl_ns: function(integer--[[Integer]])--[[void]]
+      nvim_set_hl_ns_fast: function(integer--[[Integer]])--[[void]]
       nvim_set_keymap: function(string--[[String]], string--[[String]], string--[[String]], {string:any}--[[Dictionary]])--[[void]]
       nvim_set_option: function(string--[[String]], any--[[Object]])--[[void]]
       nvim_set_option_value: function(string--[[String]], any--[[Object]], {string:any}--[[Dictionary]])--[[void]]
@@ -2097,6 +2113,7 @@ global record vim
       nvim_win_set_config: function(integer--[[Window]], {string:any}--[[Dictionary]])--[[void]]
       nvim_win_set_cursor: function(integer--[[Window]], {integer,integer}--[[ArrayOf(Integer, 2)]])--[[void]]
       nvim_win_set_height: function(integer--[[Window]], integer--[[Integer]])--[[void]]
+      nvim_win_set_hl_ns: function(integer--[[Window]], integer--[[Integer]])--[[void]]
       nvim_win_set_option: function(integer--[[Window]], string--[[String]], any--[[Object]])--[[void]]
       nvim_win_set_var: function(integer--[[Window]], string--[[String]], any--[[Object]])--[[void]]
       nvim_win_set_width: function(integer--[[Window]], integer--[[Integer]])--[[void]]


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #166 

## How to Test

1. Test with the neotest example from the issue, `lazy_required_fn('neotest', 'run.run')()`

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
