### PR TITLE
save scratchpad contents to a cache file

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ require('legendary').setup({
     -- either 'print' or 'float'
     -- Pressing q or <ESC> will close the float
     display_results = 'float',
+    -- cache the contents of the scratchpad to a file and restore it
+    -- next time you open the scratchpad
+    cache_file = string.format('%s/%s', vim.fn.stdpath('cache'), 'legendary_scratch.lua'),
   },
 })
 ```

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -24,6 +24,7 @@ local M = {
    auto_register_which_key = true,
    scratchpad = {
       display_results = 'float',
+      cache_file = string.format('%s/%s', vim.fn.stdpath('cache'), 'legendary_scratch.lua'),
    },
 }
 
@@ -68,7 +69,7 @@ function M.setup(new_config)
    M.functions = (new_config.functions or M.functions)
    M.which_key = default_whichkey(new_config.which_key)
    M.auto_register_which_key = default_bool(new_config.auto_register_which_key, M.auto_register_which_key)
-   M.scratchpad = (new_config.scratchpad or M.scratchpad)
+   M.scratchpad = vim.tbl_deep_extend('force', M.scratchpad, (new_config.scratchpad or {}))
    require('legendary.types').validate_config(M)
    return M
 end

--- a/lua/legendary/scratchpad.lua
+++ b/lua/legendary/scratchpad.lua
@@ -118,22 +118,32 @@ local function load_cache(buf)
    end
 
    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+   vim.bo.ft = 'lua'
 end
 
 local function write_cache_autocmd(buf)
    vim.api.nvim_create_autocmd('TextChanged', {
       callback = function()
-         local config = require('legendary.config').scratchpad
-         local cache_path = config and config.cache_file or string.format('%s/%s', vim.fn.stdpath('cache'), 'legendary/scratch.lua')
-         local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-         local file = io.open(cache_path, 'w+')
-         if not file then
-            return
-         end
+         pcall(function()
+            local config = require('legendary.config').scratchpad
+            local cache_path = config and config.cache_file or string.format('%s/%s', vim.fn.stdpath('cache'), 'legendary/scratch.lua')
+            local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+            local file = io.open(cache_path, 'w+')
+            if not file then
+               return
+            end
 
-         local line_ending = vim.fn.has('win32') == 1 and '\r\n' or '\n'
-         file:write(table.concat(lines, line_ending))
-         file:close()
+            local line_ending = vim.fn.has('win32') == 1 and '\r\n' or '\n'
+            file:write(table.concat(lines, line_ending))
+            file:close()
+         end)
+      end,
+      buffer = buf,
+   })
+
+   vim.api.nvim_create_autocmd('BufReadCmd', {
+      callback = function()
+         pcall(load_cache, buf)
       end,
       buffer = buf,
    })
@@ -148,7 +158,7 @@ function M.create_scratchpad_buffer()
    vim.api.nvim_buf_set_option(buf_id, 'filetype', 'lua')
    vim.api.nvim_buf_set_option(buf_id, 'buftype', 'nofile')
    vim.api.nvim_buf_set_name(buf_id, 'Legendary Scratchpad')
-   load_cache(buf_id)
+   pcall(load_cache, buf_id)
    write_cache_autocmd(buf_id)
    vim.api.nvim_win_set_buf(0, buf_id)
    vim.cmd('redrawstatus')

--- a/lua/legendary/types.lua
+++ b/lua/legendary/types.lua
@@ -173,6 +173,7 @@ unpack = ((_G).unpack or _tl_table_unpack)
 
 
 
+
  LegendaryConfig = {}
 
 

--- a/plugin/legendary.lua
+++ b/plugin/legendary.lua
@@ -10,4 +10,5 @@ if not vim.keymap or not vim.keymap.set then
 end
 
 require('legendary.cmds').bind()
+
 vim.g.legendary_loaded = true

--- a/teal/legendary/config.tl
+++ b/teal/legendary/config.tl
@@ -24,6 +24,7 @@ local M: LegendaryConfig = {
   auto_register_which_key = true,
   scratchpad = {
     display_results = 'float',
+    cache_file = string.format('%s/%s', vim.fn.stdpath('cache'), 'legendary_scratch.lua'),
   },
 }
 
@@ -68,7 +69,7 @@ function M.setup(new_config: table): LegendaryConfig
   M.functions = (new_config.functions or M.functions) as {LegendaryFunction}
   M.which_key = default_whichkey(new_config.which_key as table)
   M.auto_register_which_key = default_bool(new_config.auto_register_which_key as boolean | nil, M.auto_register_which_key)
-  M.scratchpad = (new_config.scratchpad or M.scratchpad) as LegendaryScratchpadConfig
+  M.scratchpad = vim.tbl_deep_extend('force', M.scratchpad as table, (new_config.scratchpad or {}) as table) as LegendaryScratchpadConfig
   require('legendary.types').validate_config(M)
   return M
 end

--- a/teal/legendary/scratchpad.tl
+++ b/teal/legendary/scratchpad.tl
@@ -9,19 +9,6 @@ local display_strategies = {
   'print',
 }
 
-function M.create_scratchpad_buffer()
-  if last_scratchpad_buf_id ~= nil then
-    pcall(vim.api.nvim_buf_delete, last_scratchpad_buf_id, { force = true })
-  end
-
-  local buf_id = vim.api.nvim_create_buf(true, true)
-  vim.api.nvim_buf_set_option(buf_id, 'filetype', 'lua')
-  vim.api.nvim_buf_set_option(buf_id, 'buftype', 'nofile')
-  vim.api.nvim_buf_set_name(buf_id, 'Legendary Scratchpad')
-  vim.api.nvim_win_set_buf(0, buf_id)
-  last_scratchpad_buf_id = buf_id
-end
-
 local function create_results_floating_win(lines: {string})
   if last_results_buf_id ~= nil then
     pcall(vim.api.nvim_buf_delete, last_results_buf_id, { force = true })
@@ -117,6 +104,58 @@ function M.exec_lua(lua_str: string)
     print_multiline(result)
   end
 end
+
+local function load_cache(buf: integer)
+  local config = require('legendary.config').scratchpad
+  local cache_path = config and config.cache_file or string.format('%s/%s', vim.fn.stdpath('cache'), 'legendary/scratch.lua')
+  if vim.fn.filereadable(cache_path) == 0 then
+    return
+  end
+
+  local lines = {}
+  for line in io.lines(cache_path) do
+    lines[#lines + 1] = line
+  end
+
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+end
+
+local function write_cache_autocmd(buf: integer)
+  vim.api.nvim_create_autocmd('TextChanged', {
+    callback = function()
+      local config = require('legendary.config').scratchpad
+      local cache_path = config and config.cache_file or string.format('%s/%s', vim.fn.stdpath('cache'), 'legendary/scratch.lua')
+      local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      local file = io.open(cache_path, 'w+')
+      if not file then
+        return
+      end
+
+      local line_ending = vim.fn.has('win32') == 1 and '\r\n' or '\n'
+      file:write(table.concat(lines, line_ending))
+      file:close()
+    end,
+    buffer = buf
+  })
+end
+
+function M.create_scratchpad_buffer()
+  if last_scratchpad_buf_id ~= nil then
+    pcall(vim.api.nvim_buf_delete, last_scratchpad_buf_id, { force = true })
+  end
+
+  local buf_id = vim.api.nvim_create_buf(true, true)
+  vim.api.nvim_buf_set_option(buf_id, 'filetype', 'lua')
+  vim.api.nvim_buf_set_option(buf_id, 'buftype', 'nofile')
+  vim.api.nvim_buf_set_name(buf_id, 'Legendary Scratchpad')
+  load_cache(buf_id)
+  write_cache_autocmd(buf_id)
+  vim.api.nvim_win_set_buf(0, buf_id)
+  vim.cmd('redrawstatus')
+  last_scratchpad_buf_id = buf_id
+end
+
+
 
 function M.lua_eval_current_line()
   local current_line = vim.api.nvim_get_current_line()

--- a/teal/legendary/scratchpad.tl
+++ b/teal/legendary/scratchpad.tl
@@ -118,24 +118,34 @@ local function load_cache(buf: integer)
   end
 
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo.ft = 'lua' -- this needs to be reset on load
 end
 
 local function write_cache_autocmd(buf: integer)
   vim.api.nvim_create_autocmd('TextChanged', {
     callback = function()
-      local config = require('legendary.config').scratchpad
-      local cache_path = config and config.cache_file or string.format('%s/%s', vim.fn.stdpath('cache'), 'legendary/scratch.lua')
-      local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-      local file = io.open(cache_path, 'w+')
-      if not file then
-        return
-      end
+      pcall(function()
+        local config = require('legendary.config').scratchpad
+        local cache_path = config and config.cache_file or string.format('%s/%s', vim.fn.stdpath('cache'), 'legendary/scratch.lua')
+        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+        local file = io.open(cache_path, 'w+')
+        if not file then
+          return
+        end
 
-      local line_ending = vim.fn.has('win32') == 1 and '\r\n' or '\n'
-      file:write(table.concat(lines, line_ending))
-      file:close()
+        local line_ending = vim.fn.has('win32') == 1 and '\r\n' or '\n'
+        file:write(table.concat(lines, line_ending))
+        file:close()
+      end)
     end,
-    buffer = buf
+    buffer = buf,
+  })
+
+  vim.api.nvim_create_autocmd('BufReadCmd', {
+    callback = function()
+      pcall(load_cache, buf)
+    end,
+    buffer = buf,
   })
 end
 
@@ -148,7 +158,7 @@ function M.create_scratchpad_buffer()
   vim.api.nvim_buf_set_option(buf_id, 'filetype', 'lua')
   vim.api.nvim_buf_set_option(buf_id, 'buftype', 'nofile')
   vim.api.nvim_buf_set_name(buf_id, 'Legendary Scratchpad')
-  load_cache(buf_id)
+  pcall(load_cache, buf_id)
   write_cache_autocmd(buf_id)
   vim.api.nvim_win_set_buf(0, buf_id)
   vim.cmd('redrawstatus')

--- a/teal/legendary/types.tl
+++ b/teal/legendary/types.tl
@@ -158,6 +158,7 @@ end
 ---@class LegendaryScratchpadConfig The config table for the Legendary scratchpad
 global record LegendaryScratchpadConfig
    display_results: LegendaryScratchpadDisplay
+   cache_file: string
 end
 
 ---@class LegendaryConfig Configuration table for legendary


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #169 

## How to Test

1. Put stuff in scratchpad
2. Close scratchpad 
3. Reopen scratchpad 
4. It should have the original contents
5. Quit Neovim
6. Reopen Neovim and scratchpad
7. It should have the original contents

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
