### PR TITLE
fix which-key parsing

### DIFF
--- a/lua/legendary/compat/which-key.lua
+++ b/lua/legendary/compat/which-key.lua
@@ -12,8 +12,10 @@ local function wk_to_legendary(wk, wk_opts)
    if wk_opts and wk_opts.mode then
       legendary.mode = wk_opts.mode
    end
-   legendary.description = wk.label
+   legendary.description = wk.label or vim.tbl_get(wk, 'opts', 'desc')
    legendary.opts = wk.opts or {}
+   vim.notify(vim.inspect(legendary))
+   print(vim.inspect(legendary))
    return legendary
 end
 
@@ -27,17 +29,16 @@ function M.parse_whichkey(which_key_tbls, which_key_opts, do_binding)
    if do_binding == nil then
       do_binding = true
    end
-   local wk_parsed = ((_G['require']('which-key.keys')).parse_mappings)(
-   {},
+   local wk_parsed = ((_G['require']('which-key.mappings')).parse)(
    which_key_tbls,
-   which_key_opts and (which_key_opts.prefix) or '')
+   which_key_opts)
 
    local legendary_tbls = {}
    vim.tbl_map(function(wk)
 
 
 
-      if not wk.label or ((type(wk.group) == 'boolean' and not wk.group) or (wk.group ~= nil and tostring(wk.group) ~= '')) or wk.buf ~= nil then
+      if not vim.tbl_get(wk, 'opts', 'desc') or wk.group == true then
          goto continue
       end
 

--- a/lua/legendary/compat/which-key.lua
+++ b/lua/legendary/compat/which-key.lua
@@ -14,8 +14,6 @@ local function wk_to_legendary(wk, wk_opts)
    end
    legendary.description = wk.label or vim.tbl_get(wk, 'opts', 'desc')
    legendary.opts = wk.opts or {}
-   vim.notify(vim.inspect(legendary))
-   print(vim.inspect(legendary))
    return legendary
 end
 

--- a/teal/legendary/compat/which-key.tl
+++ b/teal/legendary/compat/which-key.tl
@@ -12,8 +12,10 @@ local function wk_to_legendary(wk: table, wk_opts: table): LegendaryKeymap
   if wk_opts and wk_opts.mode then
     legendary.mode = wk_opts.mode
   end
-  legendary.description = wk.label
+  legendary.description = wk.label or vim.tbl_get(wk, 'opts', 'desc')
   legendary.opts = wk.opts or {}
+  vim.notify(vim.inspect(legendary))
+  print(vim.inspect(legendary))
   return legendary as LegendaryKeymap
 end
 
@@ -27,17 +29,16 @@ function M.parse_whichkey(which_key_tbls: {table}, which_key_opts: table, do_bin
   if do_binding == nil then
     do_binding = true
   end
-  local wk_parsed = ((_G['require']('which-key.keys') as table).parse_mappings as function(_: table, tbls: {table}, prefix: string): table)(
-    {},
+  local wk_parsed = ((_G['require']('which-key.mappings') as table).parse as function(tbls: {table}, opts: table): table)(
     which_key_tbls,
-    which_key_opts and (which_key_opts.prefix as string | nil) or ''
+    which_key_opts
   )
   local legendary_tbls: {LegendaryKeymap} = {}
   vim.tbl_map(function(wk: table): nil
     -- check wk.group because these don't represent standalone keymaps
     -- they basically represent a "folder" of other keymaps
     -- TODO support which-key mappings with buf values
-    if not wk.label or ((type(wk.group) == 'boolean' and not wk.group) or (wk.group ~= nil and tostring(wk.group) ~= '')) or wk.buf ~= nil then
+    if not vim.tbl_get(wk, 'opts', 'desc') or wk.group == true then
       goto continue
     end
 

--- a/teal/legendary/compat/which-key.tl
+++ b/teal/legendary/compat/which-key.tl
@@ -14,8 +14,6 @@ local function wk_to_legendary(wk: table, wk_opts: table): LegendaryKeymap
   end
   legendary.description = wk.label or vim.tbl_get(wk, 'opts', 'desc')
   legendary.opts = wk.opts or {}
-  vim.notify(vim.inspect(legendary))
-  print(vim.inspect(legendary))
   return legendary as LegendaryKeymap
 end
 


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #181 

## How to Test

1. Which-key.nvim keymaps should be added to legendary.nvim when using the integration

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
