### PR TITLE
allow default options to be passed to keymaps, commands, and autocmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ require('legendary').setup({
   autocmds = {},
   -- Initial functions to bidn
   functions = {},
+  -- default opts to merge with the `opts` table
+  -- of each individual item
+  default_opts = {
+    keymaps = {},
+    commands = {},
+    autocmds = {},
+  },
   -- Customize the prompt that appears on your vim.ui.select() handler
   -- Can be a string or a function that returns a string.
   select_prompt = ' legendary.nvim ',

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -5,8 +5,15 @@ local config = {
   commands = {},
   -- Initial augroups/autocmds to bind
   autocmds = {},
-  -- Initial functions to bidn
+  -- Initial functions to bind
   functions = {},
+  -- default opts to merge with the `opts` table
+  -- of each individual item
+  default_opts = {
+    keymaps = {},
+    commands = {},
+    autocmds = {},
+  },
   -- Customize the prompt that appears on your vim.ui.select() handler
   -- Can be a string or a function that returns a string.
   select_prompt = ' legendary.nvim ',
@@ -72,11 +79,18 @@ local config = {
 ---@field float_border string
 ---@field keep_contents boolean
 
+---@class LegendaryDefaultOptsConfig
+---@field keymaps table
+---@field commands table
+---@field autocmds table
+---@field functions table
+
 ---@class LegendaryConfig
 ---@field keymaps Keymap[]
 ---@field commands Command[]
 ---@field autocmds (Augroup|Autocmd)[]
 ---@field functions Function[]
+---@field default_opts LegendaryDefaultOptsConfig
 ---@field select_prompt string|fun():string
 ---@field col_separator_char string
 ---@field default_item_formatter LegendaryItemFormatter

--- a/lua/legendary/data/autocmd.lua
+++ b/lua/legendary/data/autocmd.lua
@@ -1,5 +1,6 @@
 local class = require('legendary.vendor.middleclass')
 local util = require('legendary.util')
+local Config = require('legendary.config')
 
 ---@class Autocmd
 ---@field events string[]
@@ -40,6 +41,7 @@ function Autocmd:apply()
     command = type(self.implementation) == 'string' and self.implementation or nil,
     group = self.group,
   }, self.opts or {})
+  opts = vim.tbl_deep_extend('keep', opts, Config.default_opts.autocmds or {})
   vim.api.nvim_create_autocmd(self.events, opts)
   return self
 end

--- a/lua/legendary/data/command.lua
+++ b/lua/legendary/data/command.lua
@@ -1,5 +1,6 @@
 local class = require('legendary.vendor.middleclass')
 local util = require('legendary.util')
+local Config = require('legendary.config')
 
 ---@class Command
 ---@field cmd string
@@ -41,6 +42,7 @@ function Command:apply()
   end
 
   local opts = vim.deepcopy(self.opts or {})
+  opts = vim.tbl_deep_extend('keep', opts, Config.default_opts.commands or {})
   opts.desc = opts.desc or self.description
   -- these are valid legendary.nvim options but
   -- are only used for filtering and aren't used

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -1,5 +1,6 @@
 local class = require('legendary.vendor.middleclass')
 local util = require('legendary.util')
+local Config = require('legendary.config')
 
 ---@class ModeKeymapOpts
 ---@field implementation string|function
@@ -87,8 +88,8 @@ end
 function Keymap:apply()
   for mode, mapping in pairs(self.mode_mappings) do
     local opts = vim.tbl_deep_extend('keep', mapping.opts or {}, self.opts or {})
+    opts = vim.tbl_deep_extend('keep', opts, Config.default_opts.keymaps or {})
     opts.desc = opts.desc or self.description
-    opts.silent = util.bool_default(opts.silent, true)
     vim.keymap.set(mode, self.keys, mapping.implementation, opts)
   end
 

--- a/tests/legendary/data/autocmd_spec.lua
+++ b/tests/legendary/data/autocmd_spec.lua
@@ -98,6 +98,31 @@ describe('Autocmd', function()
       })[1]
       assert.are.same(autocmd.callback, tbl[2])
     end)
+
+    it('merges opts with default_opts from config', function()
+      require('legendary.config').default_opts.autocmds = { pattern = '*.lua', once = true }
+
+      local group = vim.api.nvim_create_augroup('_LegendaryAutocmdTest_', { clear = true })
+      local tbl = {
+        'BufEnter',
+        function() end,
+        opts = {
+          group = group,
+        },
+      }
+      Autocmd:parse(tbl):apply()
+      local autocmd = vim.api.nvim_get_autocmds({
+        event = 'BufEnter',
+        group = group,
+        pattern = '*.lua',
+      })[1]
+
+      assert.are.same(autocmd.pattern, '*.lua')
+      assert.True(autocmd.once)
+
+      -- cleanup
+      require('legendary.config').default_opts.autocmds = {}
+    end)
   end)
 
   describe('with_group', function()

--- a/tests/legendary/data/command_spec.lua
+++ b/tests/legendary/data/command_spec.lua
@@ -62,5 +62,26 @@ describe('Command', function()
         assert.are.same(commands.MyCommand.name, 'MyCommand')
       end
     )
+
+    it('merges opts with default_opts from config', function()
+      require('legendary.config').default_opts.commands = { nargs = '?', bang = true }
+
+      local tbl = {
+        ':MyCommand [some arg] {another arg}<cr>',
+        function() end,
+        description = 'My command',
+      }
+      Command:parse(tbl):apply()
+      local commands = vim.api.nvim_get_commands({ builtin = false })
+      -- get the version with args, like "MyCommand [some arg] {another arg}"
+      local command = vim.tbl_filter(function(cmd)
+        return vim.startswith(cmd.name, 'MyCommand') and cmd.name ~= 'MyCommand'
+      end, commands)[1]
+      assert.are.same(command.nargs, '?')
+      assert.True(command.bang)
+
+      -- cleanup
+      require('legendary.config').default_opts.commands = {}
+    end)
   end)
 end)

--- a/tests/legendary/data/keymap_spec.lua
+++ b/tests/legendary/data/keymap_spec.lua
@@ -74,6 +74,36 @@ describe('Keymap', function()
       assert.are.same(visual_keymap.lhs, string.format('%st', vim.g.mapleader or '\\'))
       assert.are.same(type(visual_keymap.callback), 'function')
     end)
+
+    it('merges opts with default_opts from config', function()
+      require('legendary.config').default_opts.keymaps = { silent = true, nowait = true }
+
+      Keymap:parse({
+        '<leader>t',
+        {
+          n = function() end,
+          v = function() end,
+        },
+        description = 'LegendaryKeymapTest',
+      }):apply()
+
+      ---@type table
+      local normal_keymap = vim.tbl_filter(function(k)
+        return k.desc == 'LegendaryKeymapTest'
+      end, vim.api.nvim_get_keymap('n'))[1]
+      assert.are.same(normal_keymap.silent, 1)
+      assert.are.same(normal_keymap.nowait, 1)
+
+      ---@type table
+      local visual_keymap = vim.tbl_filter(function(k)
+        return k.desc == 'LegendaryKeymapTest'
+      end, vim.api.nvim_get_keymap('v'))[1]
+      assert.are.same(visual_keymap.silent, 1)
+      assert.are.same(visual_keymap.nowait, 1)
+
+      -- cleanup
+      require('legendary.config').default_opts.keymaps = {}
+    end)
   end)
 
   describe('from_vimscript', function()


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #201 

## How to Test

1. Run tests
1. Set default opts and make sure they apply by default

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
