### PR TITLE
Allow per-mode implementations for commands

### DIFF
--- a/doc/table_structures/COMMANDS.md
+++ b/doc/table_structures/COMMANDS.md
@@ -12,10 +12,53 @@ local commands = {
 }
 ```
 
+You can also create per-mode implementations, like per-mode keymappings, but since they are all bound
+to the same command, per-mode implementations for commands may only be a `function` or a `string` (not a `table`),
+since they cannot have separate `opts`.
+
+```lua
+local commands = {
+  {
+    -- example command for toggling comment with Comment.nvim
+    ':Comment',
+    {
+      n = 'gcc',
+      v = 'gc',
+    },
+    description = 'Toggle comment',
+  },
+  {
+    ':DoSomething',
+    {
+      n = ':SomethingElse<CR>',
+      v = function()
+        print('Do something else in visual mode')
+      end,
+      c = function()
+        print('Do another thing in command mode')
+      end,
+    },
+    description = 'Do stuff per-mode',
+  },
+}
+```
+
 You can also pass options to the command via the `opts` property, see `:h nvim_create_user_command` to
 see available options. In addition to those options, `legendary.nvim` adds handling for an additional
 `buffer` option (a buffer handle, or `0` for current buffer), which will cause the command to be bound
 as a buffer-local command.
+
+For "anonymous" commands (commands you want to appear in the finder but don't need `legendary.nvim` to
+handle creating), just omit the second entry (the "implementation"):
+
+```lua
+local commands = {
+  {
+    ':LspRestart',
+    description = 'Restart any attached LSP clients',
+  },
+}
+```
 
 If you need a command to take an argument, specify `unfinished = true` to pre-fill the command line instead
 of executing the command on selected. You can put an argument name/hint in `[]` or `{}` that will be stripped
@@ -26,17 +69,17 @@ local commands = {
   { ':MyCommand {some_argument}<CR>', description = 'Command with argument', unfinished = true },
   -- or
   { ':MyCommand [some_argument]<CR>', description = 'Command with argument', unfinished = true },
-}
-```
-
-For "anonymous" commands (commands you want to appear in the finder but don't need `legendary.nvim` to
-handle creating), just omit the second entry (the "implementation"):
-
-```lua
-local commands = {
+  -- and, with an implementation
   {
-    ':LspRestart',
-    description = 'Restart any attached LSP clients',
+    ':MyCommand [some_argument]<CR>',
+    function(input)
+      -- see :h nvim_create_user_command
+      if input.fargs and input.fargs[1] and input.fargs[1] == 'some expected value' then
+        -- do something with input.fargs[1]
+      end
+    end,
+    description = 'Command with argument handling',
+    unfinished = true,
   },
 }
 ```

--- a/lua/legendary/api/executor.lua
+++ b/lua/legendary/api/executor.lua
@@ -1,10 +1,7 @@
 local Toolbox = require('legendary.toolbox')
+local util = require('legendary.util')
 
 local M = {}
-
-local function exec_feedkeys(keys)
-  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(keys, true, false, true), 't', true)
-end
 
 ---@class LegendaryEditorContext
 ---@field buf integer
@@ -56,18 +53,18 @@ function M.exec_item(item, context)
       elseif Toolbox.is_command(item) then
         local cmd = item:vim_cmd()
         if item.unfinished == true then
-          exec_feedkeys(string.format(':%s ', cmd))
+          util.exec_feedkeys(string.format(':%s ', cmd))
         else
           vim.cmd(cmd)
         end
       elseif Toolbox.is_keymap(item) then
-        exec_feedkeys(item.keys)
+        util.exec_feedkeys(item.keys)
       elseif Toolbox.is_autocmd(item) then
         local impl = item.implementation
         if type(impl) == 'function' then
           impl()
         else
-          exec_feedkeys(impl)
+          util.exec_feedkeys(impl)
         end
       end
     end)

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -3,7 +3,7 @@ local util = require('legendary.util')
 local Config = require('legendary.config')
 
 ---@class ModeKeymapOpts
----@field implementation string|function
+---@field implementation string|fun()
 ---@field opts table|nil
 
 ---@class ModeKeymap

--- a/lua/legendary/util.lua
+++ b/lua/legendary/util.lua
@@ -57,4 +57,11 @@ function M.sanitize_cmd_str(cmd_str)
   return vim.trim(cmd)
 end
 
+---Execute the given keys via `vim.api.nvim_feedkeys`,
+---`keys` are escaped using `vim.api.nvim_replace_termcodes`
+---@param keys string
+function M.exec_feedkeys(keys)
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(keys, true, false, true), 't', true)
+end
+
 return M

--- a/tests/legendary/data/command_spec.lua
+++ b/tests/legendary/data/command_spec.lua
@@ -34,6 +34,35 @@ describe('Command', function()
       assert.are.same(command.opts, { bang = true, nargs = '?' })
       assert.True(command.unfinished)
     end)
+
+    it('parses per-mode implementations into a function that handles mode-implementation lookup', function()
+      local normal_executed = false
+      local visual_executed = false
+      local tbl = {
+        ':MyCommand',
+        {
+          n = function()
+            normal_executed = true
+          end,
+          x = function()
+            visual_executed = true
+          end,
+        },
+        description = 'Per-mode implementation command',
+      }
+      local command = Command:parse(tbl):apply()
+      assert.are.same(type(command.implementation), 'function')
+
+      vim.cmd('MyCommand')
+      assert.True(normal_executed)
+
+      -- switch to visual mode
+      vim.cmd('normal v')
+      assert.are.same(vim.fn.mode(), 'v')
+      -- execute in visual mode
+      vim.cmd('MyCommand')
+      assert.True(visual_executed)
+    end)
   end)
 
   describe('apply', function()


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #215 

## How to Test

An example command for `Comment.nvim` comment toggling:

```lua
require('legendary').command({
  ':Comment',
  {
    n = 'gcc',
    v = 'gc',
  },
  description = 'Toggle comment',
})
```

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
