### PR TITLE
Fix mode filters

### DIFF
--- a/lua/legendary/data/command.lua
+++ b/lua/legendary/data/command.lua
@@ -41,13 +41,11 @@ local function parse_modemap(map)
     local impl = map[mode]
     if not impl then
       if Toolbox.is_visual_mode(mode) then
-        impl = impl or map.v or map.x
+        impl = impl or map.v or map.x or map.s
       elseif mode == 'i' then
         impl = impl or map.l
       elseif mode == 'c' then
         impl = impl or map.l
-      elseif mode == 's' then
-        impl = impl or map.s or map.v
       end
     end
 

--- a/lua/legendary/filters.lua
+++ b/lua/legendary/filters.lua
@@ -15,13 +15,22 @@ function M.mode(mode)
       return true
     end
 
-    local keymap = item
-    local keymap_mode = keymap.mode or { 'n' }
-    if type(keymap_mode) == 'string' then
-      keymap_mode = { keymap_mode }
+    -- map mode equivalencies
+    local filter_modes = { mode }
+    if mode == 'v' then
+      filter_modes = { 'v', 'x', 's' }
+    elseif mode == 's' then
+      filter_modes = { 'v', 's' }
+    elseif mode == 'l' then
+      filter_modes = { 'l', 'i', 'c' }
     end
 
-    return vim.tbl_contains(keymap_mode, mode)
+    -- filter where any filter_modes match any item:modes()
+    return #vim.tbl_filter(function(keymap_mode)
+      return #vim.tbl_filter(function(filter_mode)
+        return filter_mode == keymap_mode
+      end, filter_modes) > 0
+    end, item:modes()) > 0
   end
 end
 


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #220 

## How to Test

1. See reproduction steps in issue.

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
