### PR TITLE
feat(sort): Sort by "frecency" if sqlite is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Define your keymaps, commands, and autocommands as simple Lua tables, building a
 - Help execute commands that take arguments by prefilling the command line instead of executing immediately
 - Search built-in keymaps and commands along with your user-defined keymaps and commands (may be disabled in config). Notice some missing? Comment on [this discussion](https://github.com/mrjones2014/legendary.nvim/discussions/89) or submit a PR!
 - A `legendary.toolbox` module to help create lazily-evaluated keymaps and commands, and item filter. Have an idea for a new helper? Comment on [this discussion](https://github.com/mrjones2014/legendary.nvim/discussions/90) or submit a PR!
+- Sort by [frecency](https://en.wikipedia.org/wiki/Frecency)
 - A parser to convert Vimscript keymap commands (e.g. `vnoremap <silent> <leader>f :SomeCommand<CR>`) to `legendary.nvim` keymap tables (see [Converting Keymaps From Vimscript](./doc/API.md#converting-keymaps-from-vimscript))
 - Anonymous mappings; show mappings/commands in the finder without having `legendary.nvim` handle creating them
 
@@ -58,14 +59,26 @@ With `packer.nvim`:
 
 ```lua
 -- to use a version
-use({ 'mrjones2014/legendary.nvim', tag = 'v2.1.0' })
+use({
+  'mrjones2014/legendary.nvim',
+  tag = 'v2.1.0',
+  -- sqlite is only needed if you want to use frecency sorting
+  -- requires = 'kkharji/sqlite.lua'
+})
 -- or, to get rolling updates
-use({ 'mrjones2014/legendary.nvim' })
+use({
+  'mrjones2014/legendary.nvim'
+  -- sqlite is only needed if you want to use frecency sorting
+  -- requires = 'kkharji/sqlite.lua'
+})
 ```
 
 With `vim-plug`:
 
 ```VimL
+" if you want to use frecency sorting, sqlite is also needed
+Plug "kkharji/sqlite.lua"
+
 " to use a version
 Plug "mrjones2014/legendary.nvim", { 'tag': 'v2.1.0' }
 " or, to get rolling updates
@@ -261,6 +274,19 @@ require('legendary').setup({
     -- sort the specified item type before other item types,
     -- value must be one of: 'keymap', 'command', 'autocmd', nil
     item_type_bias = nil,
+    -- settings for frecency sorting.
+    -- https://en.wikipedia.org/wiki/Frecency
+    -- Set `frecency = false` to disable.
+    -- this feature requires sqlite.lua (https://github.com/tami5/sqlite.lua)
+    -- and will be automatically disabled if sqlite is not available.
+    -- NOTE: THIS TAKES PRECEDENCE OVER OTHER SORT OPTIONS!
+    frecency = {
+      -- the directory to store the database in
+      db_root = string.format('%s/legendary/', vim.fn.stdpath('data')),
+      -- the maximum number of timestamps for a single item
+      -- to store in the database
+      max_timestamps = 10,
+    },
   },
   which_key = {
     -- Automatically add which-key tables to legendary

--- a/lua/legendary/api/cmds.lua
+++ b/lua/legendary/api/cmds.lua
@@ -132,6 +132,26 @@ end, {
     end,
     description = 'Open the log file for legendary.nvim',
   },
+  {
+    ':LegendaryFrecencyReset',
+    function()
+      require('legendary.api.db.wrapper').delete_db()
+    end,
+    description = 'Reset the frecency database',
+  },
+  {
+    ':LegendaryLogLevel',
+    function(args)
+      local log_level = vim.tbl_get(args, 'fargs', 1)
+      if not vim.tbl_contains(require('legendary.log').levels, log_level) then
+        error(string.format('Invalid log level %s', log_level))
+        return
+      end
+      require('legendary.config').log_level = log_level
+    end,
+    description = 'Convenience command to set log level',
+    opts = { nargs = 1 },
+  },
 })
 
 M.bind = function()

--- a/lua/legendary/api/db/client.lua
+++ b/lua/legendary/api/db/client.lua
@@ -3,7 +3,6 @@
 
 local DbWrapper = require('legendary.api.db.wrapper')
 local Config = require('legendary.config')
-local Log = require('legendary.log')
 
 -- modifier used as a weight in the recency_score calculation:
 local recency_modifier = {

--- a/lua/legendary/api/db/client.lua
+++ b/lua/legendary/api/db/client.lua
@@ -1,0 +1,84 @@
+-- Some code in this file is modified from the MIT licensed code at
+-- https://github.com/nvim-telescope/telescope-frecency.nvim
+
+local DbWrapper = require('legendary.api.db.wrapper')
+local Config = require('legendary.config')
+local Log = require('legendary.log')
+
+-- modifier used as a weight in the recency_score calculation:
+local recency_modifier = {
+  [1] = { age = 240, value = 100 }, -- past 4 hours
+  [2] = { age = 1440, value = 80 }, -- past day
+  [3] = { age = 4320, value = 60 }, -- past 3 days
+  [4] = { age = 10080, value = 40 }, -- past week
+  [5] = { age = 43200, value = 20 }, -- past month
+  [6] = { age = 129600, value = 10 }, -- past 90 days
+}
+
+local function item_score(frequency, timestamps)
+  local recency_score = 0
+  for _, ts in pairs(timestamps) do
+    for _, rank in ipairs(recency_modifier) do
+      if ts.age <= rank.age then
+        recency_score = recency_score + rank.value
+        goto continue
+      end
+    end
+    ::continue::
+  end
+
+  return frequency * recency_score / Config.sort.frecency.max_timestamps
+end
+
+local function filter_timestamps(timestamps, item_id)
+  local res = {}
+  for _, entry in pairs(timestamps) do
+    if entry.item_id == item_id then
+      table.insert(res, entry)
+    end
+  end
+  return res
+end
+
+---@class LegendaryDbClient
+local M = {}
+
+M.db_wrapper = nil
+
+---@return LegendaryDbClient
+function M.init()
+  if M.db_wrapper then
+    return M
+  end
+
+  M.db_wrapper = DbWrapper:new()
+  M.db_wrapper:bootstrap()
+  return M
+end
+
+function M.get_item_scores()
+  if not M.db_wrapper then
+    return {}
+  end
+
+  local item_entries = M.db_wrapper:transaction(M.db_wrapper.queries.item_get_entries, {})
+  local timestamp_ages = M.db_wrapper:transaction(M.db_wrapper.queries.timestamp_get_all_entry_ages, {})
+  local scores = {}
+  if #item_entries == 0 then
+    return scores
+  end
+
+  for _, item_entry in ipairs(item_entries) do
+    local score = item_entry.count == 0 and 0
+      or item_score(item_entry.count, filter_timestamps(timestamp_ages, item_entry.item_id))
+    scores[item_entry.item_id] = score
+  end
+
+  return scores
+end
+
+function M.update_item_score(item)
+  M.db_wrapper:update(item)
+end
+
+return M

--- a/lua/legendary/api/db/client.lua
+++ b/lua/legendary/api/db/client.lua
@@ -80,4 +80,8 @@ function M.update_item_score(item)
   M.db_wrapper:update(item)
 end
 
+function M.sql_escape(str)
+  return M.db_wrapper.sql_escape(str)
+end
+
 return M

--- a/lua/legendary/api/db/wrapper.lua
+++ b/lua/legendary/api/db/wrapper.lua
@@ -39,6 +39,13 @@ function M:new()
   return wrapper
 end
 
+function M.delete_db()
+  local db_path = string.format('%s%s', Config.sort.frecency.db_root, db_name)
+  if vim.fn.filereadable(db_path) == 1 then
+    vim.fn.delete(db_path)
+  end
+end
+
 function M:bootstrap()
   if self.db then
     return

--- a/lua/legendary/api/db/wrapper.lua
+++ b/lua/legendary/api/db/wrapper.lua
@@ -44,6 +44,8 @@ function M.delete_db()
   if vim.fn.filereadable(db_path) == 1 then
     vim.fn.delete(db_path)
   end
+
+  M:new():bootstrap()
 end
 
 function M:bootstrap()

--- a/lua/legendary/api/db/wrapper.lua
+++ b/lua/legendary/api/db/wrapper.lua
@@ -1,0 +1,169 @@
+-- Some code in this file is modified from the MIT licensed code at
+-- https://github.com/nvim-telescope/telescope-frecency.nvim
+
+local ok, sqlite = pcall(require, 'sqlite')
+if not ok then
+  error('Frecency sorting requires sqlite.lua (https://github.com/tami5/sqlite.lua) ' .. tostring(sqlite))
+  return
+end
+
+local Config = require('legendary.config')
+local Log = require('legendary.log')
+
+local db_name = 'legendary_frecency.sqlite3'
+
+---@class legendaryDbTables
+---@field item_count string
+---@field timestamps string
+local db_tables = {
+  item_count = 'item_count',
+  timestamps = 'timestamps',
+}
+
+local cmd = {
+  select = 1,
+  insert = 2,
+  delete = 3,
+  eval = 4,
+}
+
+---@class DbWrapper
+local M = {}
+
+---@return DbWrapper
+function M:new()
+  local wrapper = {}
+  setmetatable(wrapper, self)
+  self.__index = self
+  self.db = nil
+  return wrapper
+end
+
+function M:bootstrap()
+  if self.db then
+    return
+  end
+
+  Log.trace('Initializing frecency database...')
+
+  if vim.fn.isdirectory(Config.sort.frecency.db_root) == 0 then
+    vim.fn.mkdir(Config.sort.frecency.db_root, 'p')
+  end
+
+  local db_path = string.format('%s%s', Config.sort.frecency.db_root, db_name)
+  local db_ok, db_opened = pcall(function()
+    return sqlite:open(db_path)
+  end)
+  if not db_ok then
+    Log.error('Failed to open database at %s: %s', db_path, db_opened)
+    return
+  else
+    self.db = db_opened
+  end
+
+  local first_run = false
+  if not self.db:exists(db_tables.item_count) then
+    first_run = true
+    self.db:create(db_tables.item_count, {
+      id = { 'INTEGER', 'PRIMARY', 'KEY' },
+      item_id = { 'TEXT' },
+      count = { 'INTEGER' },
+    })
+    self.db:create(db_tables.timestamps, {
+      id = { 'INTEGER', 'PRIMARY', 'KEY' },
+      item_id = { 'TEXT' },
+      timestamp = { 'REAL' },
+    })
+  end
+
+  self.db:close()
+  Log.trace('Frecency database initialized.')
+  return first_run
+end
+
+function M:transaction(t, params)
+  Log.trace('Performing SQL transaction with following data: %s', vim.inspect({ query = t, params = params }))
+  return self.db:with_open(function(db)
+    local case = {
+      [cmd.select] = function()
+        return db:select(t.cmd_data, params)
+      end,
+      [cmd.insert] = function()
+        return db:insert(t.cmd_data, params)
+      end,
+      [cmd.delete] = function()
+        return db.delete(t.cmd_data, params)
+      end,
+      [cmd.eval] = function()
+        return db:eval(t.cmd_data, params)
+      end,
+    }
+    return case[t.cmd]()
+  end)
+end
+
+M.queries = {
+  item_add_entry = {
+    cmd = cmd.insert,
+    cmd_data = db_tables.item_count,
+  },
+  item_delete_entry = {
+    cmd = cmd.delete,
+    cmd_data = db_tables.item_count,
+  },
+  item_get_entries = {
+    cmd = cmd.select,
+    cmd_data = db_tables.item_count,
+  },
+  item_update_counter = {
+    cmd = cmd.eval,
+    cmd_data = 'UPDATE item_count SET count = count + 1 WHERE item_id == :item_id;',
+  },
+  timestamp_add_entry = {
+    cmd = cmd.eval,
+    cmd_data = "INSERT INTO timestamps (item_id, timestamp) values(:item_id, julianday('now'));",
+  },
+  timestamp_delete_entry = {
+    cmd = cmd.delete,
+    cmd_data = db_tables.timestamps,
+  },
+  timestamp_get_all_entries = {
+    cmd = cmd.select,
+    cmd_data = db_tables.timestamps,
+  },
+  timestamp_get_all_entry_ages = {
+    cmd = cmd.eval,
+    cmd_data = "SELECT id, item_id, CAST((julianday('now') - julianday(timestamp)) * 24 * 60 AS INTEGER) AS age FROM timestamps;", -- luacheck: no max line length
+  },
+  timestamp_delete_before_id = {
+    cmd = cmd.eval,
+    cmd_data = 'DELETE FROM timestamps WHERE id < :id and item_id == :item_id;',
+  },
+}
+
+local function row_id(row)
+  return (not vim.tbl_isempty(row)) and row[1].id or nil
+end
+
+---Update the stored data for an item
+---@param item LegendaryItem
+function M:update(item)
+  local item_id = string.format('"%s"', vim.fn.escape(item:id(), '"'))
+  Log.trace('Updating item with ID "%s"', item_id)
+  local entry_id = row_id(self:transaction(self.queries.item_get_entries, { where = { item_id = item_id } }))
+  if not entry_id then
+    self:transaction(self.queries.item_add_entry, { item_id = item_id, count = 1 })
+  end
+
+  -- create timestamp entry for this update
+  self:transaction(self.queries.timestamp_add_entry, { item_id = item_id })
+
+  -- trim timestamps table to Config.sort.frecency.max_timestamps
+  local timestamps = self:transaction(self.queries.timestamp_get_all_entries, { where = { item_id = item_id } })
+  local trim_at = timestamps[(#timestamps - Config.sort.frecency.max_timestamps) + 1]
+  if trim_at then
+    self:transaction(self.queries.timestamp_delete_before_id, { id = trim_at.id, item_id = item_id })
+  end
+end
+
+return M

--- a/lua/legendary/api/db/wrapper.lua
+++ b/lua/legendary/api/db/wrapper.lua
@@ -148,7 +148,7 @@ end
 ---Update the stored data for an item
 ---@param item LegendaryItem
 function M:update(item)
-  local item_id = string.format('"%s"', vim.fn.escape(item:id(), '"'))
+  local item_id = string.format("'%s'", string.gsub(item:id(), "'", "\\'"))
   Log.trace('Updating item with ID "%s"', item_id)
   local entry_id = row_id(self:transaction(self.queries.item_get_entries, { where = { item_id = item_id } }))
   if not entry_id then

--- a/lua/legendary/api/db/wrapper.lua
+++ b/lua/legendary/api/db/wrapper.lua
@@ -152,10 +152,14 @@ local function row_id(row)
   return (not vim.tbl_isempty(row)) and row[1].id or nil
 end
 
+function M.sql_escape(str)
+  return string.format("'%s'", string.gsub(str, "'", "\\'"))
+end
+
 ---Update the stored data for an item
 ---@param item LegendaryItem
 function M:update(item)
-  local item_id = string.format("'%s'", string.gsub(item:id(), "'", "\\'"))
+  local item_id = M.sql_escape(item:id())
   Log.trace('Updating item with ID "%s"', item_id)
   local entry_id = row_id(self:transaction(self.queries.item_get_entries, { where = { item_id = item_id } }))
   if not entry_id then

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -66,6 +66,19 @@ local config = {
     -- sort the specified item type before other item types,
     -- value must be one of: 'keymap', 'command', 'autocmd', nil
     item_type_bias = nil,
+    -- settings for frecency sorting.
+    -- https://en.wikipedia.org/wiki/Frecency
+    -- this feature requires sqlite.lua (https://github.com/tami5/sqlite.lua)
+    -- and will be automatically disabled if sqlite is not available.
+    -- NOTE: THIS TAKES PRECEDENCE OVER OTHER SORT OPTIONS!
+    -- Set `frecency = false` to disable.
+    frecency = {
+      -- the directory to store the database in
+      db_root = string.format('%s/legendary/', vim.fn.stdpath('data')),
+      -- the maximum number of timestamps for a single item
+      -- to store in the database
+      max_timestamps = 10,
+    },
   },
   which_key = {
     -- Automatically add which-key tables to legendary
@@ -118,10 +131,15 @@ local config = {
 ---@field autocmds table
 ---@field funcs table
 
+---@class LegendaryFrecencyConfig
+---@field db_root string
+---@field max_timestamps number
+
 ---@class LegendarySortOpts
 ---@field most_recent_first boolean
 ---@field user_items_first boolean
 ---@field item_type_bias 'keymap'|'command'|'autocmd'|nil
+---@field frecency LegendaryFrecencyConfig|false
 
 ---@class LegendaryConfig
 ---@field keymaps Keymap[]

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -68,10 +68,10 @@ local config = {
     item_type_bias = nil,
     -- settings for frecency sorting.
     -- https://en.wikipedia.org/wiki/Frecency
+    -- Set `frecency = false` to disable.
     -- this feature requires sqlite.lua (https://github.com/tami5/sqlite.lua)
     -- and will be automatically disabled if sqlite is not available.
     -- NOTE: THIS TAKES PRECEDENCE OVER OTHER SORT OPTIONS!
-    -- Set `frecency = false` to disable.
     frecency = {
       -- the directory to store the database in
       db_root = string.format('%s/legendary/', vim.fn.stdpath('data')),

--- a/lua/legendary/data/itemgroup.lua
+++ b/lua/legendary/data/itemgroup.lua
@@ -58,4 +58,9 @@ function ItemGroup:apply()
   return self
 end
 
+---Get a unique ID for the item group
+function ItemGroup:id()
+  return self.name
+end
+
 return ItemGroup

--- a/lua/legendary/data/itemlist.lua
+++ b/lua/legendary/data/itemlist.lua
@@ -115,7 +115,7 @@ function ItemList:sort_inplace()
       -- inline require because this module requires sqlite and is a bit heavier
       local DbClient = require('legendary.api.db.client').init()
       local frecency_scores = DbClient.get_item_scores()
-      Log.inspect(frecency_scores)
+      Log.debug('Computed item scores: %s', vim.inspect(frecency_scores))
 
       local ok, sorted = pcall(
         Sorter.mergesort,
@@ -123,8 +123,10 @@ function ItemList:sort_inplace()
         ---@param item1 LegendaryItem
         ---@param item2 LegendaryItem
         function(item1, item2)
-          local item1_score = frecency_scores[item1:id()] or 0
-          local item2_score = frecency_scores[item2:id()] or 0
+          local item1_id = DbClient.sql_escape(item1:id())
+          local item2_id = DbClient.sql_escape(item2:id())
+          local item1_score = frecency_scores[item1_id] or 0
+          local item2_score = frecency_scores[item2_id] or 0
           return item1_score > item2_score
         end
       )

--- a/lua/legendary/data/itemlist.lua
+++ b/lua/legendary/data/itemlist.lua
@@ -42,7 +42,7 @@ function ItemList:add(items)
         .. 'a programming error, please submit an issue at https://github.com/mrjones2014/legendary.nvim'
       Log.debug(msg)
     elseif Toolbox.is_itemgroup(item) then
-      local group = self.itemgroup_refs[item.name] or item --[[@as ItemGroup]]
+      local group = self.itemgroup_refs[item:id()] or item --[[@as ItemGroup]]
       if group ~= item then
         group.items:add(item.items.items)
         group.icon = group.icon or item.icon
@@ -89,13 +89,6 @@ function ItemList:filter(filters)
   end, self.items)
 end
 
----Sort *in place* to move the most
----recent item to the top.
----THIS MODIFIES THE LIST IN PLACE.
-function ItemList:sort_inplace_by_recent()
-  self:sort_inplace({ most_recent_first = true })
-end
-
 ---Sort the list *IN PLACE* according to config.
 --THIS MODIFIES THE LIST IN PLACE.
 function ItemList:sort_inplace()
@@ -115,6 +108,39 @@ function ItemList:sort_inplace()
   end
 
   local items = self.items
+
+  if Config.sort.frecency ~= false then
+    local has_sqlite, _ = pcall(require, 'sqlite')
+    if has_sqlite then
+      -- inline require because this module requires sqlite and is a bit heavier
+      local DbClient = require('legendary.api.db.client').init()
+      local frecency_scores = DbClient.get_item_scores()
+      Log.inspect(frecency_scores)
+
+      local ok, sorted = pcall(
+        Sorter.mergesort,
+        items,
+        ---@param item1 LegendaryItem
+        ---@param item2 LegendaryItem
+        function(item1, item2)
+          local item1_score = frecency_scores[item1:id()] or 0
+          local item2_score = frecency_scores[item2:id()] or 0
+          return item1_score > item2_score
+        end
+      )
+
+      if not ok then
+        Log.error('Failed to sort items: %s', vim.inspect(sorted))
+      else
+        items = sorted
+      end
+
+      self.items = items
+      return
+    else
+      Log.debug('Config.sort.frecency is enabled, but sqlite is not availabe, so frecency is automatically disabled.')
+    end
+  end
 
   ---@param item1 LegendaryItem
   ---@param item2 LegendaryItem
@@ -148,7 +174,7 @@ function ItemList:sort_inplace()
 
   local ok, sorted = pcall(Sorter.mergesort, items, comparator)
   if not ok then
-    vim.api.nvim_err_write(string.format('[legendary.nvim] Failed to sort items: %s\n', vim.inspect(sorted)))
+    Log.error('Failed to sort items: %s', vim.inspect(sorted))
   else
     items = sorted
   end

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -101,7 +101,7 @@ function Keymap:apply()
 end
 
 function Keymap:id()
-  return string.format('%s %s %s', self.keys, self:modes(), self.description)
+  return string.format('%s %s %s', self.keys, table.concat(self:modes(), ','), self.description)
 end
 
 function Keymap:modes()

--- a/lua/legendary/log.lua
+++ b/lua/legendary/log.lua
@@ -73,6 +73,8 @@ end
 ---@field fatal fun(...)
 local M = {}
 
+M.levels = levels
+
 for _, level in ipairs(levels) do
   M[level] = function(...)
     local msg = format(...)

--- a/lua/legendary/ui/init.lua
+++ b/lua/legendary/ui/init.lua
@@ -2,7 +2,7 @@
 local Config = require('legendary.config')
 ---@type LegendaryState
 local State = require('legendary.data.state')
-local ItemGroup = require('legendary.data.itemgroup')
+local Toolbox = require('legendary.toolbox')
 local Format = require('legendary.ui.format')
 local Executor = require('legendary.api.executor')
 local Log = require('legendary.log')
@@ -39,7 +39,9 @@ local function select_inner(opts, itemlist)
     Log.trace('Launching select UI')
   end
 
+  itemlist = itemlist or State.items
   opts = opts or {}
+
   local prompt = opts.select_prompt or Config.select_prompt
   if type(prompt) == 'function' then
     prompt = prompt()
@@ -51,13 +53,13 @@ local function select_inner(opts, itemlist)
   -- implementation of `sort_inplace` checks if
   -- sorting is actually needed and does nothing
   -- if it does not need to be sorted.
-  State.items:sort_inplace()
+  itemlist:sort_inplace()
 
   -- in addition to user filters, we also need to filter by buf
   local items = vim.tbl_filter(function(item)
     local item_buf = vim.tbl_get(item, 'opts', 'buffer')
     return item_buf == nil or item_buf == context.buf
-  end, (itemlist or State.items):filter(opts.filters or {}))
+  end, itemlist:filter(opts.filters or {}))
 
   local padding = Format.compute_padding(items, opts.formatter or Config.default_item_formatter, context.mode)
 
@@ -78,7 +80,7 @@ local function select_inner(opts, itemlist)
     end
 
     State.most_recent_item = selected
-    if selected.class == ItemGroup then
+    if Toolbox.is_itemgroup(selected) then
       return select_inner(opts, selected.items)
     end
 

--- a/lua/legendary/ui/init.lua
+++ b/lua/legendary/ui/init.lua
@@ -11,6 +11,7 @@ local function update_item_frecency_score(item)
   if Config.sort.frecency ~= false then
     local has_sqlite, _ = pcall(require, 'sqlite')
     if has_sqlite then
+      Log.trace('Updating scoring data for selected item.')
       local DbClient = require('legendary.api.db.client').init()
       DbClient.update_item_score(item)
     else


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #235 

## How to Test

Update your config to include this new dependency (only required for frecency sorting): https://github.com/kkharji/sqlite.lua

e.g.

```lua
use { 'mrjones2014/legendary.nvim', requires = 'kkharji/sqlite.lua' }
```

1. Ensure that everything like item picking and execution still works
2. Test that items seem to be sorted by both frequency and recency of use
3. Test that items _within item groups_ are also sorted the same way

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
