### PR TITLE
feat: hide keymaps from itemlist

### DIFF
--- a/lua/legendary/data/itemlist.lua
+++ b/lua/legendary/data/itemlist.lua
@@ -53,7 +53,7 @@ function ItemList:add(items)
       end
       self.sorted = false
     else
-      if item.description and #item.description > 0 then
+      if item.description and #item.description > 0 and not item.hide then
         local id = item:id()
         if not self.duplicate_tracker[id] then
           self.duplicate_tracker[id] = true

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -21,6 +21,7 @@ local Config = require('legendary.config')
 ---@field keys string
 ---@field mode_mappings ModeKeymap
 ---@field description string
+---@field hide boolean
 ---@field opts table
 ---@field builtin boolean
 ---@field class Keymap
@@ -37,6 +38,7 @@ function Keymap:parse(tbl, builtin) -- luacheck: no unused
     ['2'] = { tbl[2], { 'string', 'function', 'table' }, true },
     mode = { tbl.mode, { 'string', 'table' }, true },
     opts = { tbl.opts, { 'table' }, true },
+    hide = { tbl.hide, { 'boolean' }, true },
     description = { util.get_desc(tbl), { 'string' }, true },
   })
 
@@ -57,6 +59,7 @@ function Keymap:parse(tbl, builtin) -- luacheck: no unused
   local instance = Keymap()
 
   instance.keys = tbl[1]
+  instance.hide = tbl.hide or false
   instance.description = util.get_desc(tbl)
   instance.opts = tbl.opts or {}
   instance.builtin = builtin or false

--- a/tests/legendary/data/itemlist_spec.lua
+++ b/tests/legendary/data/itemlist_spec.lua
@@ -27,6 +27,13 @@ describe('ItemList', function()
       assert.are.same(keymap, list.items[1])
       assert.are.same(#list.items, 1)
     end)
+
+    it('excludes items that are hidden', function()
+      local keymap = Keymap:parse({ '<leader><leader>', function() end, hide = true, description = 'test' })
+      local list = ItemList:create()
+      list:add({ keymap })
+      assert.are.same(#list.items, 0)
+    end)
   end)
 
   describe('filter', function()


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

## How to Test

1. Add the `hide = true` option to a keymap. For example:
```lua
{
  "<C-p>",
  require("legendary").find,
  hide = true,
  description = "Open Legendary",
  mode = { "n", "v", "i" },
},
```
2. When you open Legendary, the item should not be visible

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
