### PR TITLE
feat: allow autocmds and commands to be hidden

### DIFF
--- a/doc/table_structures/AUTOCMDS.md
+++ b/doc/table_structures/AUTOCMDS.md
@@ -41,6 +41,15 @@ local autocmds = {
     -- like a command on-demand from the finder
     description = 'Format on write with LSP',
   },
+  {
+    'BufWritePre',
+    vim.lsp.buf.format_document,
+    -- or, if you want to include a description
+    description = 'Format on write with LSP',
+    -- but still not have it in the finder,
+    -- set
+    hide = true,
+  },
 }
 ```
 

--- a/doc/table_structures/COMMANDS.md
+++ b/doc/table_structures/COMMANDS.md
@@ -12,6 +12,20 @@ local commands = {
 }
 ```
 
+If you want to include a description but not hide it from the finder UI, you can set `hide = true`:
+
+```lua
+local commands = {
+  {
+    ':DoSomething',
+    ':echo "Something"',
+    description = 'Do something!',
+    -- hide from finder UI
+    hide = true,
+  }
+}
+```
+
 You can also create per-mode implementations, like per-mode keymappings, but since they are all bound
 to the same command, per-mode implementations for commands may only be a `function` or a `string` (not a `table`),
 since they cannot have separate `opts`.

--- a/doc/table_structures/KEYMAPS.md
+++ b/doc/table_structures/KEYMAPS.md
@@ -23,6 +23,20 @@ local keymaps = {
 }
 ```
 
+If you want to include a description, but do _not_ want the item to appear in the finder:
+
+```lua
+local keymaps = {
+  {
+    '<leader>s',
+    description = 'Write all buffers',
+    opts = {},
+    -- hide from finder
+    hide = true,
+  },
+}
+```
+
 If you need to pass parameters to the Lua function or call a function dynamically from a plugin,
 you can use the following helper functions:
 

--- a/lua/legendary/data/autocmd.lua
+++ b/lua/legendary/data/autocmd.lua
@@ -21,6 +21,7 @@ function Autocmd:parse(tbl) -- luacheck: no unused
     description = { util.get_desc(tbl), { 'string' }, true },
     opts = { tbl.opts, { 'table' }, true },
     group = { tbl.group, { 'string', 'number' }, true },
+    hide = { tbl.hide, { 'boolean' }, true },
   })
 
   local instance = Autocmd()
@@ -31,6 +32,7 @@ function Autocmd:parse(tbl) -- luacheck: no unused
   instance.opts = tbl.opts
   instance.description = util.get_desc(tbl)
   instance.group = tbl.group
+  instance.hide = util.bool_default(tbl.hide, false)
 
   return instance
 end

--- a/lua/legendary/data/command.lua
+++ b/lua/legendary/data/command.lua
@@ -68,6 +68,7 @@ function Command:parse(tbl, builtin) -- luacheck: no unused
     opts = { tbl.opts, { 'table' }, true },
     description = { util.get_desc(tbl), { 'string' }, true },
     unfinished = { tbl.unfinished, { 'boolean' }, true },
+    hide = { tbl.hide, { 'boolean' }, true },
   })
 
   local instance = Command()
@@ -78,6 +79,7 @@ function Command:parse(tbl, builtin) -- luacheck: no unused
   instance.unfinished = util.bool_default(tbl.unfinished, false)
   instance.implementation = tbl[2]
   instance.builtin = builtin or false
+  instance.hide = util.bool_default(tbl.hide, false)
 
   if type(instance.implementation) == 'table' then
     vim.validate({


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #245 

## How to Test

1. See #243 

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
