### PR TITLE
feat(frecency): use separate IDs for frecency scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Define your keymaps, commands, and autocommands as simple Lua tables, building a
 - Help execute commands that take arguments by prefilling the command line instead of executing immediately
 - Search built-in keymaps and commands along with your user-defined keymaps and commands (may be disabled in config). Notice some missing? Comment on [this discussion](https://github.com/mrjones2014/legendary.nvim/discussions/89) or submit a PR!
 - A `legendary.toolbox` module to help create lazily-evaluated keymaps and commands, and item filter. Have an idea for a new helper? Comment on [this discussion](https://github.com/mrjones2014/legendary.nvim/discussions/90) or submit a PR!
-- Sort by [frecency](https://en.wikipedia.org/wiki/Frecency)
+- Sort by [frecency](https://en.wikipedia.org/wiki/Frecency), a combined measure of how frequently and how recently you've used an item from the picker
 - A parser to convert Vimscript keymap commands (e.g. `vnoremap <silent> <leader>f :SomeCommand<CR>`) to `legendary.nvim` keymap tables (see [Converting Keymaps From Vimscript](./doc/API.md#converting-keymaps-from-vimscript))
 - Anonymous mappings; show mappings/commands in the finder without having `legendary.nvim` handle creating them
 

--- a/lua/legendary/api/db/wrapper.lua
+++ b/lua/legendary/api/db/wrapper.lua
@@ -161,7 +161,7 @@ end
 ---Update the stored data for an item
 ---@param item LegendaryItem
 function M:update(item)
-  local item_id = M.sql_escape(item:id())
+  local item_id = M.sql_escape(item:frecency_id())
   Log.trace('Updating item with ID "%s"', item_id)
   local entry_id = row_id(self:transaction(self.queries.item_get_entries, { where = { item_id = item_id } }))
   if not entry_id then

--- a/lua/legendary/data/autocmd.lua
+++ b/lua/legendary/data/autocmd.lua
@@ -52,6 +52,10 @@ function Autocmd:id()
   return string.format('%s %s', table.concat(self.events, ','), self.description)
 end
 
+function Autocmd:frecency_id()
+  return self.description
+end
+
 function Autocmd:with_group(group)
   self.group = group
   return self

--- a/lua/legendary/data/command.lua
+++ b/lua/legendary/data/command.lua
@@ -123,6 +123,10 @@ function Command:id()
   return string.format('%s %s', self.cmd, self.description)
 end
 
+function Command:frecency_id()
+  return Command:id()
+end
+
 ---Return self.cmd with leading : or <cmd> and trailing <cr> removed
 function Command:vim_cmd()
   -- replace any argument placeholders for display purposes wrapped in {} or []

--- a/lua/legendary/data/command.lua
+++ b/lua/legendary/data/command.lua
@@ -124,7 +124,7 @@ function Command:id()
 end
 
 function Command:frecency_id()
-  return Command:id()
+  return self:id()
 end
 
 ---Return self.cmd with leading : or <cmd> and trailing <cr> removed

--- a/lua/legendary/data/function.lua
+++ b/lua/legendary/data/function.lua
@@ -34,4 +34,8 @@ function Function:id()
   return string.format('<function> %s %s', self.description, vim.inspect(self.opts or {}))
 end
 
+function Function:frecency_id()
+  return string.format('<function> %s', self.description)
+end
+
 return Function

--- a/lua/legendary/data/itemgroup.lua
+++ b/lua/legendary/data/itemgroup.lua
@@ -63,4 +63,8 @@ function ItemGroup:id()
   return self.name
 end
 
+function ItemGroup:frecency_id()
+  return self.name
+end
+
 return ItemGroup

--- a/lua/legendary/data/itemlist.lua
+++ b/lua/legendary/data/itemlist.lua
@@ -123,8 +123,8 @@ function ItemList:sort_inplace()
         ---@param item1 LegendaryItem
         ---@param item2 LegendaryItem
         function(item1, item2)
-          local item1_id = DbClient.sql_escape(item1:id())
-          local item2_id = DbClient.sql_escape(item2:id())
+          local item1_id = DbClient.sql_escape(item1:frecency_id())
+          local item2_id = DbClient.sql_escape(item2:frecency_id())
           local item1_score = frecency_scores[item1_id] or 0
           local item2_score = frecency_scores[item2_id] or 0
           return item1_score > item2_score

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -104,7 +104,17 @@ function Keymap:apply()
 end
 
 function Keymap:id()
-  return string.format('%s %s %s', self.keys, table.concat(self:modes(), ','), self.description)
+  return string.format(
+    '%s %s %s %s',
+    self.keys,
+    table.concat(self:modes(), ','),
+    vim.inspect(self.opts or {}),
+    self.description
+  )
+end
+
+function Keymap:frecency_id()
+  return string.format('%s', self.description)
 end
 
 function Keymap:modes()

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -104,13 +104,7 @@ function Keymap:apply()
 end
 
 function Keymap:id()
-  return string.format(
-    '%s %s %s %s',
-    self.keys,
-    table.concat(self:modes(), ','),
-    vim.inspect(self.opts or {}),
-    self.description
-  )
+  return string.format('%s %s %s', self.keys, table.concat(self:modes(), ','), self.description)
 end
 
 function Keymap:frecency_id()


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #251 

## How to Test

The only time frecency score should reset is if fields in the table below are changed:

| Item type | Fields                            |
| --------- | --------------------------------- |
| Autocmd   | `description`                     |
| Command   | name (`tbl[1]`), `description`    |
| Function  | `description`                     |
| Keymap    | `description`                     |
| Group     | `name` (`itemgroup='Group name'`) |


## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
