### PR TITLE
fix(keymaps): track mode(s) correctly for description-only keymaps

### DIFF
--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -105,7 +105,7 @@ end
 function Keymap:apply()
   if vim.tbl_islist(self.mode_mappings) then
     -- description-only keymap
-    return
+    return self
   end
 
   for mode, mapping in pairs(self.mode_mappings) do

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -103,6 +103,11 @@ end
 ---Bind the keymap in Neovim
 ---@return Keymap
 function Keymap:apply()
+  if vim.tbl_islist(self.mode_mappings) then
+    -- description-only keymap
+    return
+  end
+
   for mode, mapping in pairs(self.mode_mappings) do
     local opts = vim.tbl_deep_extend('keep', mapping.opts or {}, self.opts or {})
     opts = vim.tbl_deep_extend('keep', opts, Config.default_opts.keymaps or {})

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -66,6 +66,16 @@ function Keymap:parse(tbl, builtin) -- luacheck: no unused
 
   instance.mode_mappings = {}
   if tbl[2] == nil then
+    -- for description-only keymaps, just set mode_mappings to the list of modes
+    instance.mode_mappings = tbl.mode or { 'n' }
+    if type(instance.mode_mappings) == 'string' then
+      instance.mode_mappings = { instance.mode_mappings }
+    end
+
+    if #instance.mode_mappings == 0 then
+      instance.mode_mappings = { 'n' }
+    end
+
     return instance
   end
 
@@ -112,6 +122,10 @@ function Keymap:frecency_id()
 end
 
 function Keymap:modes()
+  if vim.tbl_islist(self.mode_mappings) then
+    return self.mode_mappings
+  end
+
   local modes = {}
   for mode, mapping in pairs(self.mode_mappings) do
     if mapping then

--- a/tests/legendary/data/keymap_spec.lua
+++ b/tests/legendary/data/keymap_spec.lua
@@ -47,6 +47,14 @@ describe('Keymap', function()
         { n = { implementation = ':NormalMode' }, v = { implementation = ':VisualMode' } }
       )
     end)
+
+    it('for description-only keymaps, mode_mappings is assigned to a list of the modes', function()
+      local tbl = { '<leader>f', description = 'test', mode = { 'n', 'v' } }
+      local keymap = Keymap:parse(tbl)
+      assert.are.same(keymap.keys, tbl[1])
+      assert.are.same(keymap.description, tbl.description)
+      assert.are.same(keymap.mode_mappings, tbl.mode)
+    end)
   end)
 
   describe('apply', function()


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #271

## How to Test

1. `require('legendary').keymap({'<leader><leader>', description = 'find me pls', mode = { 'v' }})`
2. trigger legendary from visual mode
3. search for 'find me pls'
4. item should appear

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
