### PR TITLE
fix(setup): remove duplicate `:apply()` calls

### DIFF
--- a/lua/legendary/init.lua
+++ b/lua/legendary/init.lua
@@ -96,11 +96,6 @@ function M.setup(cfg)
   M.autocmds(Config.autocmds)
   M.itemgroups(Config.itemgroups)
 
-  -- apply items
-  State.items:iter(function(item)
-    item:apply()
-  end)
-
   Log.trace('setup() parsed and applied all configuration.')
 end
 


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #270 

## How to Test

1. Follow reproduction steps in linked issue, it should no longer be reproducible

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
