### PR TITLE
fix: respect `Config.scratchpad.results_view`

### DIFF
--- a/lua/legendary/ui/scratchpad.lua
+++ b/lua/legendary/ui/scratchpad.lua
@@ -90,6 +90,11 @@ local function results_win(result, err)
     lines = vim.inspect(lines)
   end
 
+  if Config.scratchpad.results_view == 'print' then
+    print(lines)
+    return
+  end
+
   lines = vim.split(lines, '\n', { trimempty = false })
 
   if results_buf_id then


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #274 

## How to Test

1. Run the following code in the scratchpad and verify the result is printed, not put in a floating window

```lua
require('legendary.config').scratchpad.results_view = 'print'
return { 'test' }
```

## Testing for Regressions

I have tested the following:

- [ ] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [ ] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [ ] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [ ] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [ ] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
