### PR TITLE
fix(executor): Commands that accept a range will be executed with marks (`'<,'>`) added if triggered from visual mode

### DIFF
--- a/lua/legendary/api/cmds.lua
+++ b/lua/legendary/api/cmds.lua
@@ -93,6 +93,7 @@ end, {
         vim.api.nvim_err_write("Filetype must be 'lua' to eval lua code")
         return
       end
+
       require('legendary.ui.scratchpad').lua_eval_range(range.line1, range.line2)
     end,
     description = 'Eval lines selected in visual mode as Lua',

--- a/lua/legendary/api/executor.lua
+++ b/lua/legendary/api/executor.lua
@@ -56,6 +56,10 @@ function M.exec_item(item, context)
         if item.unfinished == true then
           util.exec_feedkeys(string.format(':%s ', cmd))
         else
+          -- if in visual mode, add marks
+          if Toolbox.is_visual_mode(context.mode) and not vim.startswith(cmd, "'<,'>") then
+            cmd = string.format("'<,'>%s", cmd)
+          end
           vim.cmd(cmd)
         end
       elseif Toolbox.is_keymap(item) then

--- a/lua/legendary/api/executor.lua
+++ b/lua/legendary/api/executor.lua
@@ -56,8 +56,12 @@ function M.exec_item(item, context)
         if item.unfinished == true then
           util.exec_feedkeys(string.format(':%s ', cmd))
         else
-          -- if in visual mode, add marks
-          if Toolbox.is_visual_mode(context.mode) and not vim.startswith(cmd, "'<,'>") then
+          -- if in visual mode and the command supports range, add marks
+          if
+            vim.tbl_get(item, 'opts', 'range') == true
+            and Toolbox.is_visual_mode(context.mode)
+            and not vim.startswith(cmd, "'<,'>")
+          then
             cmd = string.format("'<,'>%s", cmd)
           end
           vim.cmd(cmd)


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #277 

## How to Test

1. Execute `:LegendaryEvalLines` from visual mode on some Lua code via the finder UI
2. It should work correctly
3. Visual commands that do NOT accept marks should also still work

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
