### PR TITLE
new(scratchpad): `:LegendaryScratch` and `:LegendaryScratchToggle` now accept an argument to override `Config.scratchpad.view`

### DIFF
--- a/doc/MAPPING_DEVELOPMENT.md
+++ b/doc/MAPPING_DEVELOPMENT.md
@@ -6,6 +6,9 @@ mapping/command/autocmd development.
 ## Utility Commands
 
 - `:LegendaryScratch` - create a scratchpad buffer to test Lua snippets in
+  - Accepts an argument to override the value of `config.scratchpad.view`, you may pass one of `current`, `float`, `split`, or `vsplit`, for example `:LegendaryScratch vsplit`
+- `:LegendaryScratchToggle` - utility command to toggle the scratchpad open and closed with a single command
+  - Accepts arguments in the same way that `:LegendaryScratch` does
 - `:LegendaryEvalLine` - evaluate the current line as a Lua expression
 - `:LegendaryEvalLines` - evaluate the line range selected in visual mode as a Lua snippet
 - `:LegendaryEvalBuf` - evaluate the entire current buffer as a Lua snippet

--- a/lua/legendary/api/cmds.lua
+++ b/lua/legendary/api/cmds.lua
@@ -63,17 +63,27 @@ end, {
   },
   {
     ':LegendaryScratch',
-    function()
-      require('legendary.ui.scratchpad').open()
+    function(args)
+      local method = vim.tbl_get(args, 'fargs', 1)
+      if method ~= 'current' and method ~= 'split' and method ~= 'vsplit' and method ~= 'float' then
+        method = nil
+      end
+      require('legendary.ui.scratchpad').open(method)
     end,
     description = 'Create a Lua scratchpad buffer to help develop commands and keymaps',
+    opts = { nargs = '?' },
   },
   {
     ':LegendaryScratchToggle',
-    function()
-      require('legendary.ui.scratchpad').toggle()
+    function(args)
+      local method = vim.tbl_get(args, 'fargs', 1)
+      if method ~= 'current' and method ~= 'split' and method ~= 'vsplit' and method ~= 'float' then
+        method = nil
+      end
+      require('legendary.ui.scratchpad').toggle(method)
     end,
     description = 'Toggle the legendary.nvim Lua scratchpad buffer',
+    opts = { nargs = '?' },
   },
   {
     ':LegendaryEvalLine',

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -97,7 +97,8 @@ local config = {
   scratchpad = {
     -- How to open the scratchpad buffer,
     -- 'current' for current window, 'float'
-    -- for floating window
+    -- for floating window, 'split' for split window,
+    -- 'vsplit' for a vertical split window
     view = 'float',
     -- How to show the results of evaluated Lua code.
     -- 'print' for `print(result)`, 'float' for a floating window.


### PR DESCRIPTION


<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #279 

## How to Test

For each of `current`, `float`, `split`, and `vsplit`, run the following test where the chosen value is referred to as `[method]`:

1. `:LegendaryScratch [method]` should open the scratchpad according to specified `[method]`, overriding the value of `config.scratchpad.view`
2. `:LegendaryScratchToggle [method]` should toggle the scratchpad according to specified `[method]`, overriding the value of `config.scratchpad.view`

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
