### PR TITLE
feat(ui): Ability to filter keymaps by `filetype` and `buftype`

### DIFF
--- a/doc/table_structures/KEYMAPS.md
+++ b/doc/table_structures/KEYMAPS.md
@@ -37,12 +37,12 @@ local keymaps = {
 }
 ```
 
-Often useful for plugin keymaps, you can also specify a `filetype` or `buftype` to automatically filter
+Often useful for plugin keymaps, you can also specify `opts.filetype` or `opts.buftype` to automatically filter
 out keymaps based on `filetype` and `buftype` respectively.
 
 ```lua
 local keymaps = {
-  { '<C-v>', filetype = 'NvimTree', description = 'NvimTree: Open file in vertical split' },
+  { '<C-v>', opts = { filetype = 'NvimTree' }, description = 'NvimTree: Open file in vertical split' },
 }
 ```
 

--- a/doc/table_structures/KEYMAPS.md
+++ b/doc/table_structures/KEYMAPS.md
@@ -37,6 +37,15 @@ local keymaps = {
 }
 ```
 
+Often useful for plugin keymaps, you can also specify a `filetype` or `buftype` to automatically filter
+out keymaps based on `filetype` and `buftype` respectively.
+
+```lua
+local keymaps = {
+  { '<C-v>', filetype = 'NvimTree', description = 'NvimTree: Open file in vertical split' },
+}
+```
+
 If you need to pass parameters to the Lua function or call a function dynamically from a plugin,
 you can use the following helper functions:
 
@@ -55,7 +64,7 @@ the `mode` property:
 
 ```lua
 local keymaps = {
-  { '<leader>c', ':CommentToggle<CR>', description = 'Toggle comment', mode = { 'n', 'v' } }
+  { '<leader>c', ':CommentToggle<CR>', description = 'Toggle comment', mode = { 'n', 'v' } },
 }
 ```
 
@@ -64,7 +73,7 @@ element as a table, where the table keys are the modes:
 
 ```lua
 local keymaps = {
-  { '<leader>c', { n = ':CommentToggle<CR>', v = ':VisualCommentToggle<CR>' }, description = 'Toggle comment' }
+  { '<leader>c', { n = ':CommentToggle<CR>', v = ':VisualCommentToggle<CR>' }, description = 'Toggle comment' },
 }
 ```
 
@@ -126,7 +135,7 @@ local keymaps = {
     '<leader>fm',
     vim.lsp.buf.formatting_sync,
     description = 'Format buffer with LSP',
-    opts = { silent = true, noremap = true }
+    opts = { silent = true, noremap = true },
   },
 }
 ```
@@ -151,7 +160,7 @@ local keymaps = {
     end,
     description = 'Toggle comment',
     mode = { 'n', 'v' },
-  }
+  },
 }
 ```
 

--- a/lua/legendary/api/executor.lua
+++ b/lua/legendary/api/executor.lua
@@ -5,18 +5,23 @@ local util = require('legendary.util')
 local M = {}
 
 ---@class LegendaryEditorContext
----@field buf integer
----@field mode string
+---@field buf integer Buffer ID
+---@field ft string Buffer's filetype
+---@field bt string Buffer's buftype
+---@field mode string Current mode
 ---@field cursor_pos integer[] { row, col }
 ---@field marks integer[]|nil
 
 ---Build a context object containing information about the editor
 ---state *before* triggering the finder so that it can be
 ---restored before executing the item.
----@return table
+---@return LegendaryEditorContext
 function M.build_pre_context()
+  local buf = vim.api.nvim_get_current_buf()
   return {
-    buf = vim.api.nvim_get_current_buf(),
+    buf = buf,
+    ft = vim.api.nvim_buf_get_option(buf, 'filetype'),
+    bt = vim.api.nvim_buf_get_option(buf, 'buftype'),
     mode = vim.fn.mode(),
     cursor_pos = vim.api.nvim_win_get_cursor(vim.api.nvim_get_current_win()),
     marks = Toolbox.get_marks(),

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -67,8 +67,6 @@ function Keymap:parse(tbl, builtin) -- luacheck: no unused
   instance.description = util.get_desc(tbl)
   instance.opts = tbl.opts or {}
   instance.builtin = builtin or false
-  instance.filetype = tbl.filetype
-  instance.buftype = tbl.buftype
 
   instance.mode_mappings = {}
   if tbl[2] == nil then
@@ -118,6 +116,9 @@ function Keymap:apply()
     local opts = vim.tbl_deep_extend('keep', mapping.opts or {}, self.opts or {})
     opts = vim.tbl_deep_extend('keep', opts, Config.default_opts.keymaps or {})
     opts.desc = opts.desc or self.description
+    -- these opts are used by legendary.nvim but not by the Neovim API
+    opts.filetype = nil
+    opts.buftype = nil
     vim.keymap.set(mode, self.keys, mapping.implementation, opts)
   end
 

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -22,6 +22,8 @@ local Config = require('legendary.config')
 ---@field mode_mappings ModeKeymap
 ---@field description string
 ---@field hide boolean
+---@field filetype string
+---@field buftype string
 ---@field opts table
 ---@field builtin boolean
 ---@field class Keymap
@@ -39,6 +41,8 @@ function Keymap:parse(tbl, builtin) -- luacheck: no unused
     mode = { tbl.mode, { 'string', 'table' }, true },
     opts = { tbl.opts, { 'table' }, true },
     hide = { tbl.hide, { 'boolean' }, true },
+    filetype = { tbl.filetype, { 'string' }, true },
+    buftype = { tbl.buftype, { 'string' }, true },
     description = { util.get_desc(tbl), { 'string' }, true },
   })
 
@@ -63,6 +67,8 @@ function Keymap:parse(tbl, builtin) -- luacheck: no unused
   instance.description = util.get_desc(tbl)
   instance.opts = tbl.opts or {}
   instance.builtin = builtin or false
+  instance.filetype = tbl.filetype
+  instance.buftype = tbl.buftype
 
   instance.mode_mappings = {}
   if tbl[2] == nil then

--- a/lua/legendary/log.lua
+++ b/lua/legendary/log.lua
@@ -22,14 +22,19 @@ local level_hls = {
   fatal = 'ErrorMsg',
 }
 
-local prefix = '[legendary.nvim] '
 local prefix_hl = 'Comment'
 
-local function log_with_hl(msg, hl)
+local function get_prefix(level)
+  return string.format('[%s][legendary.nvim][%s]', os.date(), string.upper(level))
+end
+
+local function log_with_hl(msg, level)
+  local prefix = get_prefix(level)
+  local hl = level_hls[level]
   vim.cmd(string.format('echohl %s', prefix_hl))
   vim.cmd(string.format('echom "%s"', vim.fn.escape(prefix, '"')))
   vim.cmd(string.format('echohl %s', hl or 'NONE'))
-  vim.cmd(string.format('echom "%s"', vim.fn.escape(msg, '"')))
+  vim.cmd(string.format('echom "%s"', string.gsub(vim.fn.escape(msg, '"'), '\n', '\\n')))
   vim.cmd('echohl NONE')
 end
 
@@ -85,14 +90,14 @@ for _, level in ipairs(levels) do
     end
 
     local lines = logfile:read()
-    table.insert(lines, 1, string.format('[%s]%s%s', os.date(), prefix, msg))
+    table.insert(lines, 1, string.format('%s %s', get_prefix(level), msg))
     lines = vim.list_slice(lines, 1, math.min(#lines, MAX_LOG_LINES))
     logfile:write(lines)
 
     if not should_log(level) then
       return
     end
-    log_with_hl(msg, level_hls[level])
+    log_with_hl(msg, level)
   end
 end
 

--- a/lua/legendary/ui/init.lua
+++ b/lua/legendary/ui/init.lua
@@ -95,7 +95,7 @@ end
 local M = {}
 
 ---@class LegendaryFindOpts
----@field filters LegendaryItemFilter[]
+---@field filters LegendaryItemFilter|LegendaryItemFilter[]
 ---@field select_prompt string|fun():string
 ---@field formatter LegendaryItemFormatter
 

--- a/lua/legendary/ui/init.lua
+++ b/lua/legendary/ui/init.lua
@@ -41,8 +41,8 @@ local function resolve_items(items, context, filters)
     Toolbox.is_keymap,
     function(item)
       local item_buf = vim.tbl_get(item, 'opts', 'buffer')
-      local item_ft = vim.tbl_get(item, 'filetype')
-      local item_bt = vim.tbl_get(item, 'buftype')
+      local item_ft = vim.tbl_get(item, 'opts', 'filetype')
+      local item_bt = vim.tbl_get(item, 'opts', 'buftype')
       local matches_buf = item_buf == nil or item_buf == context.buf
       local matches_ft = item_ft == nil or item_ft == context.ft
       local matches_bt = item_bt == nil or item_bt == context.bt
@@ -55,9 +55,7 @@ local function resolve_items(items, context, filters)
       specificity_map[keymap.keys] = keymap
     else
       local existing = specificity_map[keymap.keys] --[[ @as Keymap ]]
-      if keymap.keys == '<leader>qq' then
-        print(vim.tbl_islist(keymap))
-      end
+
       -- check buf, filetype, buftype, and builtin
       if
         vim.tbl_get(existing, 'opts', 'buffer') ~= context.buf
@@ -65,15 +63,15 @@ local function resolve_items(items, context, filters)
       then
         specificity_map[keymap.keys] = keymap
       elseif
-        vim.tbl_get(existing, 'filetype') ~= context.ft
-        and #context.ft > 0
-        and vim.tbl_get(keymap, 'filetype') == context.ft
+        #context.ft > 0
+        and vim.tbl_get(existing, 'opts', 'filetype') ~= context.ft
+        and vim.tbl_get(keymap, 'opts', 'filetype') == context.ft
       then
         specificity_map[keymap.keys] = keymap
       elseif
-        vim.tbl_get(existing, 'buftype') ~= context.bt
-        and #context.bt > 0
-        and vim.tbl_get(keymap, 'buftype') == context.bt
+        #context.bt > 0
+        and vim.tbl_get(existing, 'opts', 'buftype') ~= context.bt
+        and vim.tbl_get(keymap, 'opts', 'buftype') == context.bt
       then
         specificity_map[keymap.keys] = keymap
       elseif existing.builtin and not keymap.builtin then


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #256

Implements filtering keymaps by filetype and buftype, as well as keymaps taking precedence based on specificity.

## How to Test

1. As an example, add a keymap like this: `{ '<C-v>', opts = { filetype = 'NvimTree' }, description = 'NvimTree: Open file in vertical split' }`
2. Add another keymap like this: `{ '<C-v>`, description = 'Notice this has the same keys as above' }`
3. Open legendary.nvim in a normal buffer
4. Search for `<C-v>`
5. The 2nd keymap you added should show up, the nvim-tree one should not
6. Open nvim-tree
7. Open legendary.nvim from the nvim-tree buffer
8. Search for `<C-v>`
9. The nvim-tree keymap should show up and the other one should not

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
