### PR TITLE
feat: support overriding icons for default items formatter

### DIFF
--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -33,6 +33,13 @@ local config = {
   -- See function `default_format(item)` in
   -- `lua/legendary/ui/format.lua` to see default implementation.
   default_item_formatter = nil,
+  -- Icons that by defualt are shown when using the default formatter
+  icons = {
+    keymap = nil,
+    command = '',
+    fn = '',
+    itemgroup = '',
+  },
   -- Include builtins by default, set to false to disable
   include_builtin = true,
   -- Include the commands that legendary.nvim creates itself

--- a/lua/legendary/ui/format.lua
+++ b/lua/legendary/ui/format.lua
@@ -17,13 +17,13 @@ end
 function M.default_format(item)
   if Toolbox.is_keymap(item) then
     return {
-      table.concat(item:modes(), ', '),
+      Config.icons.keymap or table.concat(item:modes(), ', '),
       item.keys,
       item.description,
     }
   elseif Toolbox.is_command(item) then
     return {
-      '',
+      Config.icons.command,
       item.cmd,
       item.description,
     }
@@ -35,13 +35,13 @@ function M.default_format(item)
     }
   elseif Toolbox.is_function(item) then
     return {
-      '',
+      Config.icons.fn,
       '<function>',
       item.description,
     }
   elseif Toolbox.is_itemgroup(item) then
     return {
-      item.icon or '',
+      item.icon or Config.icons.itemgroup,
       item.name,
       item.description or 'Expand to select an item...',
     }


### PR DESCRIPTION
Thanks for the plugin 💙 

The case where you don't have the necessary font to display the default icons but also have no need to replace the whole `default_formatter_function`