### PR TITLE
feat: Support for `which-key.nvim` groups into `legendary.nvim` `ItemGroups`

### DIFF
--- a/lua/legendary/integrations/which-key.lua
+++ b/lua/legendary/integrations/which-key.lua
@@ -4,12 +4,27 @@ local State = require('legendary.data.state')
 local Keymap = require('legendary.data.keymap')
 local Log = require('legendary.log')
 
+local Lazy = require('legendary.vendor.lazy')
+---@type ItemGroup
+local ItemGroup = Lazy.require_on_exported_call('legendary.data.itemgroup')
+
 local M = {}
+
+local function longest_matching_group(wk, wk_groups)
+  local matching_group = {}
+  for prefix, group_data in pairs(wk_groups) do
+    if vim.startswith(wk.prefix, prefix) and #prefix > #(matching_group[1] or '') then
+      matching_group = { prefix, group_data }
+    end
+  end
+
+  return matching_group[2]
+end
 
 ---@param wk table
 ---@param wk_opts table
 ---@return table
-local function wk_to_legendary(wk, wk_opts)
+local function wk_to_legendary(wk, wk_opts, wk_groups)
   local legendary = {}
   legendary[1] = wk.prefix
   if wk.cmd then
@@ -18,9 +33,38 @@ local function wk_to_legendary(wk, wk_opts)
   if wk_opts and wk_opts.mode then
     legendary.mode = wk_opts.mode
   end
+  if wk.group == true and #wk.name > 0 then
+    legendary.itemgroup = wk.name
+  end
+  local group = longest_matching_group(wk, wk_groups)
+  if group then
+    legendary.itemgroup = group
+  end
   legendary.description = wk.label or vim.tbl_get(wk, 'opts', 'desc')
   legendary.opts = wk.opts or {}
   return legendary
+end
+
+local function parse_to_itemgroups(legendary_tbls)
+  local keymaps = {}
+  local itemgroups = {}
+  for _, keymap in ipairs(legendary_tbls) do
+    if keymap.itemgroup then
+      itemgroups[keymap.itemgroup] = itemgroups[keymap.itemgroup]
+        or {
+          itemgroup = keymap.itemgroup[1],
+          description = keymap.itemgroup[1] ~= keymap.itemgroup[2] and keymap.itemgroup[2] or nil,
+          keymaps = {},
+        }
+
+      table.insert(itemgroups[keymap.itemgroup].keymaps, keymap)
+    else
+      table.insert(keymaps, keymap)
+    end
+  end
+
+  local groups = vim.tbl_values(itemgroups)
+  return vim.list_extend(keymaps, groups, 1, #groups)
 end
 
 --- Take which-key.nvim tables
@@ -35,12 +79,15 @@ function M.parse_whichkey(which_key_tbls, which_key_opts, do_binding)
   end
   local wk_parsed = require('which-key.mappings').parse(which_key_tbls, which_key_opts)
   local legendary_tbls = {}
+  local wk_groups = {}
+  vim.tbl_map(function(maybe_group)
+    if maybe_group.group == true and maybe_group.name then
+      wk_groups[maybe_group.prefix] = { maybe_group.name, maybe_group.label }
+    end
+  end, wk_parsed)
   vim.tbl_map(function(wk)
-    -- check wk.group because these don't represent standalone keymaps
-    -- they basically represent a "folder" of other keymaps
-    -- TODO support which-key mappings with buf values
     if vim.tbl_get(wk, 'opts', 'desc') and not wk.group == true then
-      table.insert(legendary_tbls, wk_to_legendary(wk, which_key_opts))
+      table.insert(legendary_tbls, wk_to_legendary(wk, which_key_opts, wk_groups))
     end
   end, wk_parsed)
 
@@ -51,7 +98,7 @@ function M.parse_whichkey(which_key_tbls, which_key_opts, do_binding)
     end, legendary_tbls)
   end
 
-  return legendary_tbls
+  return parse_to_itemgroups(legendary_tbls)
 end
 
 --- Bind a which-key.nvim table with legendary.nvim
@@ -61,7 +108,13 @@ end
 function M.bind_whichkey(wk_tbls, wk_opts, do_binding)
   local legendary_tbls = M.parse_whichkey(wk_tbls, wk_opts, do_binding)
   State.items:add(vim.tbl_map(function(keymap)
-    local parsed = Keymap:parse(keymap)
+    local parsed
+    if keymap.itemgroup and keymap.keymaps then
+      parsed = ItemGroup:parse(keymap)
+    else
+      parsed = Keymap:parse(keymap)
+    end
+
     if do_binding then
       parsed:apply()
     end


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #310 

## How to Test

1. Register an item with which-key like so:
```lua
require('which-key').register({
      f = {
        name = 'WhichKey: Files', -- optional group name
        desc = 'Some which key items',
        q = { '<cmd>Telescope find_files<cr>', 'Find File' },
      },
    }, {
      prefix = '<leader>',
    })
```

It should be registered in legendary under an item group with name `WhichKey: Files` and description `Some which key items`.
