### PR TITLE
feat(keymaps): Add syntax to filter keymaps from UI dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ The `require('legend').find()` function takes an `opts` table with the following
 ```lua
 {
   -- pass a list of filter functions or a single filter function with
-  -- the signature `function(item): boolean`
+  -- the signature `function(item, context): boolean`
+  -- (see below for `context` definition)
   -- several filter functions are provided for convenience
   -- see ./doc/FILTERS.md for a list
   filters = {},
@@ -215,6 +216,19 @@ The `require('legend').find()` function takes an `opts` table with the following
   -- pass a string, or a function that returns a string
   -- to customize the select prompt for the current call
   select_prompt = nil,
+}
+```
+
+The `context` table passed to filters contains the following properties:
+
+```lua
+{
+  buf = number, -- buffer ID
+  buftype = string,
+  filetype = string,
+  mode = string, -- the mode that the UI was triggered from
+  cursor_pos = table, -- { row, col }
+  marks = table, -- visual mode marks, if applicable; { line, col, line, col }
 }
 ```
 

--- a/doc/table_structures/AUTOCMDS.md
+++ b/doc/table_structures/AUTOCMDS.md
@@ -10,7 +10,7 @@ local augroups = {
     name = 'MyAugroupName',
     clear = true,
     -- you autocmd tables here
-  }
+  },
 }
 ```
 
@@ -78,6 +78,6 @@ local augroups = {
       group = 'filetypedetect',
       pattern = { '*.jsonc', 'tsconfig*.json' },
     },
-  }
+  },
 }
 ```

--- a/doc/table_structures/COMMANDS.md
+++ b/doc/table_structures/COMMANDS.md
@@ -1,5 +1,7 @@
 # Commands
 
+## Basic commands
+
 Command tables follow the exact same structure as [keymaps](./KEYMAPS.md), but specify
 a command name instead of a key sequence.
 
@@ -11,6 +13,8 @@ local commands = {
   { ':CommentToggle', description = 'Toggle comment' },
 }
 ```
+
+## Hiding commands from the UI
 
 If you want to include a description but not hide it from the finder UI, you can set `hide = true`:
 
@@ -25,6 +29,8 @@ local commands = {
   },
 }
 ```
+
+## Per-mode command implementations
 
 You can also create per-mode implementations, like per-mode keymappings, but since they are all bound
 to the same command, per-mode implementations for commands may only be a `function` or a `string` (not a `table`),
@@ -57,6 +63,8 @@ local commands = {
 }
 ```
 
+## Specifying command options
+
 You can also pass options to the command via the `opts` property, see `:h nvim_create_user_command` to
 see available options. In addition to those options, `legendary.nvim` adds handling for an additional
 `buffer` option (a buffer handle, or `0` for current buffer), which will cause the command to be bound
@@ -73,6 +81,8 @@ local commands = {
   },
 }
 ```
+
+## Incomplete commands
 
 If you need a command to take an argument, specify `unfinished = true` to pre-fill the command line instead
 of executing the command on selected. You can put an argument name/hint in `[]` or `{}` that will be stripped
@@ -98,6 +108,8 @@ local commands = {
   },
 }
 ```
+
+## Item groups
 
 You can also organize keymaps, commands, and functions into groups that will show up
 in the finder UI like a folder, selecting it will then trigger another finder for items

--- a/doc/table_structures/FUNCTIONS.md
+++ b/doc/table_structures/FUNCTIONS.md
@@ -1,5 +1,7 @@
 # Functions
 
+## Basic functions
+
 Functions follow a similar structure as anonymous [commands](./COMMANDS.md), but description is **required**.
 
 ```lua
@@ -13,27 +15,31 @@ local functions = {
         apply = true,
       })
     end,
-    description = "Auto Fix...",
+    description = 'Auto Fix...',
   },
   {
     function()
       if require('legendary.toolbox').is_visual_mode() then
         local cline, _, vline, _ = unpack(require('legendary.toolbox').get_marks())
-        require("gitsigns").reset_hunk({ cline, vline })
+        require('gitsigns').reset_hunk({ cline, vline })
       else
-        require("gitsigns").reset_hunk()
+        require('gitsigns').reset_hunk()
       end
     end,
-    description = "Revert Selected Ranges/Reset the lines of the hunk",
+    description = 'Revert Selected Ranges/Reset the lines of the hunk',
   },
-  { lazy(vim.cmd.Telescope, "git_files"), description = "Git Files" },
+  { lazy(vim.cmd.Telescope, 'git_files'), description = 'Git Files' },
 }
 ```
+
+## Options
 
 You can also pass options via the `opts` property:
 
 - `buffer` option (a buffer handle, or `0` for current buffer), which will
   make the function visible only in the specified buffer.
+
+## Item groups
 
 You can also organize keymaps, commands, and functions into groups that will show up
 in the finder UI like a folder, selecting it will then trigger another finder for items
@@ -42,7 +48,7 @@ within the group. If groups are given the same name, they will be merged.
 ```lua
 local functions = {
   {
-  -- name, indicates that this table is an item group
+    -- name, indicates that this table is an item group
     itemgroup = 'short ID',
     -- you can also customize the icon for item groups
     icon = '',

--- a/doc/table_structures/KEYMAPS.md
+++ b/doc/table_structures/KEYMAPS.md
@@ -1,5 +1,7 @@
 # Keymaps
 
+## Basic Keymaps
+
 For keymaps you are mapping yourself (as opposed to mappings set by other plugins),
 the first two elements are the key and the handler, respectively. The handler
 can be a command string like `:wa<CR>` or a Lua function.
@@ -13,6 +15,8 @@ local keymaps = {
 }
 ```
 
+## Adding keymaps to UI without the implementation
+
 For "anonymous" mappings (you want them to appear in the finder but don't want `legendary.nvim`
 to handle creating them, e.g. for plugin keymappings), just omit the second entry (the "implementation"):
 
@@ -22,6 +26,8 @@ local keymaps = {
   { '<leader>fm', description = 'Format buffer with LSP' },
 }
 ```
+
+## Hiding keymaps from the UI
 
 If you want to include a description, but do _not_ want the item to appear in the finder:
 
@@ -37,6 +43,8 @@ local keymaps = {
 }
 ```
 
+## Helper functions
+
 If you need to pass parameters to the Lua function or call a function dynamically from a plugin,
 you can use the following helper functions:
 
@@ -50,12 +58,14 @@ local keymaps = {
 }
 ```
 
+## Specifying mode
+
 The keymap's mode defaults to normal (`n`), but you can set a different mode, or list of modes, via
 the `mode` property:
 
 ```lua
 local keymaps = {
-  { '<leader>c', ':CommentToggle<CR>', description = 'Toggle comment', mode = { 'n', 'v' } }
+  { '<leader>c', ':CommentToggle<CR>', description = 'Toggle comment', mode = { 'n', 'v' } },
 }
 ```
 
@@ -64,7 +74,7 @@ element as a table, where the table keys are the modes:
 
 ```lua
 local keymaps = {
-  { '<leader>c', { n = ':CommentToggle<CR>', v = ':VisualCommentToggle<CR>' }, description = 'Toggle comment' }
+  { '<leader>c', { n = ':CommentToggle<CR>', v = ':VisualCommentToggle<CR>' }, description = 'Toggle comment' },
 }
 ```
 
@@ -117,6 +127,8 @@ local keymaps = {
 }
 ```
 
+## Specifying keymap options
+
 You can also pass options to the keymap via the `opts` property, see `:h vim.keymap.set` to
 see available options.
 
@@ -126,7 +138,7 @@ local keymaps = {
     '<leader>fm',
     vim.lsp.buf.formatting_sync,
     description = 'Format buffer with LSP',
-    opts = { silent = true, noremap = true }
+    opts = { silent = true, noremap = true },
   },
 }
 ```
@@ -151,19 +163,35 @@ local keymaps = {
     end,
     description = 'Toggle comment',
     mode = { 'n', 'v' },
-  }
+  },
 }
 ```
 
-If you want to register keymaps with `legendary.nvim` in order to see them in the finder, but not bind
-them (like for keymaps set by other plugins), you can just omit the handler element:
+## Special filters
+
+Sometimes, you need to add special filters to keymaps. One example where this is useful is when other plugins create
+keymaps that are only active in buffers managed by that plugin (e.g. `nvim-tree.lua` keymaps are only active in the
+`nvimtree` buffer). There are two special filters, `buftype` and `filetype` that may be specified directly, and you
+can also pass custom functions under the `filters` property. Functions receive the item and the editor context
+as parameters.
 
 ```lua
 local keymaps = {
-  { '<C-d>', description = 'Scroll docs up' },
-  { '<C-f>', description = 'Scroll docs down' },
+  {
+    '<C-v>',
+    description = 'Open file in new vertical split',
+    filters = {
+      filetype = 'NvimTree', -- can also be a list of filetypes, { 'NvimTree', 'NeoTree' }
+      buftype = 'nofile', -- can also be a list of buftypes, { 'nofile', 'acwrite' }
+      function(item, context) -- custom function filter
+        return context.mode == 'n'
+      end,
+    },
+  },
 }
 ```
+
+## Item groups
 
 You can also organize keymaps, commands, and functions into groups that will show up
 in the finder UI like a folder, selecting it will then trigger another finder for items

--- a/doc/table_structures/KEYMAPS.md
+++ b/doc/table_structures/KEYMAPS.md
@@ -167,7 +167,7 @@ local keymaps = {
 }
 ```
 
-## Special filters
+## In-place special filters
 
 Sometimes, you need to add special filters to keymaps. One example where this is useful is when other plugins create
 keymaps that are only active in buffers managed by that plugin (e.g. `nvim-tree.lua` keymaps are only active in the

--- a/lua/legendary/api/executor.lua
+++ b/lua/legendary/api/executor.lua
@@ -6,6 +6,8 @@ local M = {}
 
 ---@class LegendaryEditorContext
 ---@field buf integer
+---@field buftype string
+---@field filetype string
 ---@field mode string
 ---@field cursor_pos integer[] { row, col }
 ---@field marks integer[]|nil
@@ -13,10 +15,15 @@ local M = {}
 ---Build a context object containing information about the editor
 ---state *before* triggering the finder so that it can be
 ---restored before executing the item.
+---@param buf number buffer ID to build context for, used only for testing
+---@overload fun():LegendaryEditorContext
 ---@return table
-function M.build_pre_context()
+function M.build_context(buf)
+  buf = buf or vim.api.nvim_get_current_buf()
   return {
-    buf = vim.api.nvim_get_current_buf(),
+    buf = buf,
+    buftype = vim.api.nvim_buf_get_option(buf, 'buftype') or '',
+    filetype = vim.api.nvim_buf_get_option(buf, 'filetype') or '',
     mode = vim.fn.mode(),
     cursor_pos = vim.api.nvim_win_get_cursor(vim.api.nvim_get_current_win()),
     marks = Toolbox.get_marks(),

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -24,8 +24,65 @@ local Config = require('legendary.config')
 ---@field hide boolean
 ---@field opts table
 ---@field builtin boolean
+---@field filters table|nil
 ---@field class Keymap
 local Keymap = class('Keymap')
+
+local function buftype_filter(value)
+  return function(_, context)
+    print('!!!!!!', vim.inspect(context))
+    if type(value) == 'string' then
+      return context.buftype == value
+    else
+      for _, value_inner in ipairs(value) do
+        if context.buftype ~= value_inner then
+          return false
+        end
+      end
+      return true
+    end
+  end
+end
+
+local function filetype_filter(value)
+  return function(_, context)
+    if type(value) == 'string' then
+      return context.filetype == value
+    else
+      for _, value_inner in ipairs(value) do
+        if context.filetype ~= value_inner then
+          return false
+        end
+      end
+      return true
+    end
+  end
+end
+
+local function parse_filters(filters)
+  if not filters then
+    return nil
+  end
+
+  local result = {}
+
+  for key, value in pairs(filters) do
+    -- check special keys
+    if key == 'buftype' then
+      table.insert(result, buftype_filter(value))
+    end
+    if key == 'filetype' then
+      table.insert(result, filetype_filter(value))
+    end
+
+    -- then list items
+    if type(key) == 'number' and type(value) == 'function' then
+      table.insert(result, value)
+    end
+  end
+
+  return result
+end
 
 ---Parse a new keymap table
 ---@param tbl table
@@ -40,6 +97,7 @@ function Keymap:parse(tbl, builtin) -- luacheck: no unused
     opts = { tbl.opts, { 'table' }, true },
     hide = { tbl.hide, { 'boolean' }, true },
     description = { util.get_desc(tbl), { 'string' }, true },
+    filters = { tbl.filters, { 'table' }, true },
   })
 
   if type(tbl[2]) == 'table' then
@@ -63,6 +121,7 @@ function Keymap:parse(tbl, builtin) -- luacheck: no unused
   instance.description = util.get_desc(tbl)
   instance.opts = tbl.opts or {}
   instance.builtin = builtin or false
+  instance.filters = parse_filters(tbl.filters)
 
   instance.mode_mappings = {}
   if tbl[2] == nil then

--- a/lua/legendary/filters.lua
+++ b/lua/legendary/filters.lua
@@ -39,9 +39,9 @@ end
 ---@return LegendaryItemFilter
 function M.AND(...)
   local filters = { ... }
-  return function(item)
+  return function(item, context)
     for _, filter in ipairs(filters) do
-      if not filter(item) then
+      if not filter(item, context) then
         return false
       end
     end
@@ -55,9 +55,9 @@ end
 ---@return LegendaryItemFilter
 function M.OR(...)
   local filters = { ... }
-  return function(item)
+  return function(item, context)
     for _, filter in ipairs(filters) do
-      if filter(item) then
+      if filter(item, context) then
         return true
       end
     end

--- a/lua/legendary/util.lua
+++ b/lua/legendary/util.lua
@@ -64,4 +64,34 @@ function M.exec_feedkeys(keys)
   vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(keys, true, false, true), 't', true)
 end
 
+---Run the given function, timing it's duration and logging the performance
+---in milliseconds with the given message. The format string may contain a single `%`
+---character, which will be replaced with the duration in milliseconds.
+---@generic T
+---@param fn function the function to measure performance for
+---@param message string the format string to log the performance duration with
+---@returns T the result of the given function
+function M.log_performance(fn, message)
+  local now = vim.loop.hrtime()
+  local result = fn()
+  require('legendary.log').debug(message, (vim.loop.hrtime() - now) / 1000000)
+  return result
+end
+
+function M.eq_or_list_contains(needle, haystack)
+  if type(needle) == type(haystack) then
+    return needle == haystack
+  end
+
+  if type(haystack) == 'table' then
+    for _, value in ipairs(haystack) do
+      if value == needle then
+        return true
+      end
+    end
+  end
+
+  return false
+end
+
 return M


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #256 

## How to Test

1. Create a keymap with custom filters like `{ '<C-v>', description = 'filtree open in split', filters = { filetype = 'filetree' } }`
1. Create a new buffer and `:set filetype=filetree`
1. The keymap you created in step 1 should only appear in the UI when triggered from the `filetree` buffer
1. Repeat steps 1-3 but for a `buftype` instead of a filetype
1. Also test with a custom function filter as described in the changes to `KEYMAPS.md`

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
