### PR TITLE
feat(api): Implement extension API and nvim_tree extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Define your keymaps, commands, and autocommands as simple Lua tables, building a
 - [Keymap Development Utilities](./doc/MAPPING_DEVELOPMENT.md)
 - [`which-key.nvim` Integration](./doc/WHICH_KEY.md)
 - [Lua API](./doc/API.md)
+- [Extensions](./doc/EXTENSIONS.md)
 - [Table Structures](./doc/table_structures/README.md)
   - [Keymaps](./doc/table_structures/KEYMAPS.md)
   - [Commands](./doc/table_structures/COMMANDS.md)
@@ -46,6 +47,7 @@ Define your keymaps, commands, and autocommands as simple Lua tables, building a
 - Sort by [frecency](https://en.wikipedia.org/wiki/Frecency), a combined measure of how frequently and how recently you've used an item from the picker
 - A parser to convert Vimscript keymap commands (e.g. `vnoremap <silent> <leader>f :SomeCommand<CR>`) to `legendary.nvim` keymap tables (see [Converting Keymaps From Vimscript](./doc/API.md#converting-keymaps-from-vimscript))
 - Anonymous mappings; show mappings/commands in the finder without having `legendary.nvim` handle creating them
+- Extensions to automatically load keymaps and commands from other plugins
 
 ## Prerequisites
 
@@ -171,6 +173,10 @@ require('legendary').setup({
       -- autocmds here
     },
   },
+  extensions = {
+    -- automatically load keymaps and commands from nvim-tree.lua
+    nvim_tree = true,
+  }
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,16 @@ require('legendary').setup({
     -- if not passed, true by default
     do_binding = true,
   },
+  -- Which extensions to load; no extensions are loaded by default.
+  -- Setting the plugin name to `false` disables loading the extension.
+  -- Setting it to any other value will attempt to load the extension,
+  -- and pass the value as an argument to the extension, which should
+  -- be a single function. Extensions are modules under `legendary.extensions.*`
+  -- which return a single function, which is responsible for loading and
+  -- initializing the extension.
+  extensions = {
+    nvim_tree = false,
+  },
   scratchpad = {
     -- How to open the scratchpad buffer,
     -- 'current' for current window, 'float'

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Define your keymaps, commands, and autocommands as simple Lua tables, building a
 - A parser to convert Vimscript keymap commands (e.g. `vnoremap <silent> <leader>f :SomeCommand<CR>`) to `legendary.nvim` keymap tables (see [Converting Keymaps From Vimscript](./doc/API.md#converting-keymaps-from-vimscript))
 - Anonymous mappings; show mappings/commands in the finder without having `legendary.nvim` handle creating them
 - Extensions to automatically load keymaps and commands from other plugins
+  - The internal extension API is considered unstable, as it will likely need to evolve as we add extensions for additional plugins with different setups. This mostly affects plugin developers, not users.
 
 ## Prerequisites
 
@@ -176,7 +177,7 @@ require('legendary').setup({
   extensions = {
     -- automatically load keymaps and commands from nvim-tree.lua
     nvim_tree = true,
-  }
+  },
 })
 ```
 

--- a/doc/EXTENSIONS.md
+++ b/doc/EXTENSIONS.md
@@ -7,6 +7,11 @@
 
 <!--toc:end-->
 
+> **Note**
+> The internal extension API is considered unstable, as it will likely need to evolve as we add
+> extensions for additional plugins with different setups. This mostly affects plugin developers,
+> not users.
+
 `legendary.nvim` extensions can automatically load keymaps and commands from other plugins with
 very little configuration.
 

--- a/doc/EXTENSIONS.md
+++ b/doc/EXTENSIONS.md
@@ -1,0 +1,40 @@
+# Extensions
+
+<!--toc:start-->
+
+- [Extensions](#extensions)
+  - [`nvim-tree.lua`](#nvim-treelua)
+
+<!--toc:end-->
+
+`legendary.nvim` extensions can automatically load keymaps and commands from other plugins with
+very little configuration.
+
+To enable a plugin, specify it in your `legendary.nvim` config, under `extensions`, where the key
+is the extension name and the value is the extension config (or `false` to disable an extension).
+
+```lua
+require('legendary').setup({
+  extensions = {
+    -- nvim-tree.lua extension takes no config,
+    -- just use `true`
+    nvim_tree = true,
+    -- this table will be passed as extension config
+    some_extension = {
+      some_extension_config = some_value,
+    },
+  },
+})
+```
+
+## `nvim-tree.lua`
+
+Automatically load keymaps and commands for the `NvimTree` buffer into `legendary.nvim`.
+
+```lua
+require('legendary').setup({
+  extensions = {
+    nvim_tree = true,
+  },
+})
+```

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -101,6 +101,16 @@ local config = {
     -- if not passed, true by default
     do_binding = true,
   },
+  -- Which extensions to load; no extensions are loaded by default.
+  -- Setting the plugin name to `false` disables loading the extension.
+  -- Setting it to any other value will attempt to load the extension,
+  -- and pass the value as an argument to the extension, which should
+  -- be a single function. Extensions are modules under `legendary.extensions.*`
+  -- which return a single function, which is responsible for loading and
+  -- initializing the extension.
+  extensions = {
+    nvim_tree = false,
+  },
   scratchpad = {
     -- How to open the scratchpad buffer,
     -- 'current' for current window, 'float'
@@ -163,6 +173,7 @@ local config = {
 ---@field include_legendary_cmds boolean
 ---@field sort LegendarySortOpts
 ---@field which_key LegendaryWhichkeyConfig
+---@field extensions table<string, any>
 ---@field scratchpad LegendaryScratchpadConfig
 ---@field cache_path string
 ---@field log_level string

--- a/lua/legendary/data/itemlist.lua
+++ b/lua/legendary/data/itemlist.lua
@@ -81,7 +81,9 @@ function ItemList:filter(filters, context)
 
   return util.log_performance(function()
     return vim.tbl_filter(function(item)
-      local all_filters = filters
+      -- NOTE: The creation of a new list via vim.list_extend is important here,
+      -- otherwise the list gets added to for every item we filter
+      local all_filters = vim.list_extend({}, filters)
       if item.filters then
         all_filters = vim.list_extend(all_filters, item.filters)
       end

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -30,7 +30,6 @@ local Keymap = class('Keymap')
 
 local function buftype_filter(value)
   return function(_, context)
-    print('!!!!!!', vim.inspect(context))
     if type(value) == 'string' then
       return context.buftype == value
     else

--- a/lua/legendary/extensions/init.lua
+++ b/lua/legendary/extensions/init.lua
@@ -9,18 +9,20 @@ function M.load_all(extensions)
   end
 
   for extension_name, extension_config in pairs(extensions) do
-    local load_status, module_or_error = pcall(require, string.format('legendary.extensions.%s', extension_name))
-    if not load_status then
-      Log.error('Error loading extensions %q: %s', vim.inspect(module_or_error))
-    else
-      local module = module_or_error -- now known to not be an error
-      if type(module) ~= 'function' then
-        Log.error('Extension %q does not return a function.', extension_name)
+    if extension_config ~= false then
+      local load_status, module_or_error = pcall(require, string.format('legendary.extensions.%s', extension_name))
+      if not load_status then
+        Log.error('Error loading extensions %q: %s', vim.inspect(module_or_error))
       else
-        -- module is a function
-        local ok, error = pcall(module, extension_config)
-        if not ok then
-          Log.error('Extension %q failed to initialize: %s', vim.inspect(error))
+        local module = module_or_error -- now known to not be an error
+        if type(module) ~= 'function' then
+          Log.error('Extension %q does not return a function.', extension_name)
+        else
+          -- module is a function
+          local ok, error = pcall(module, extension_config)
+          if not ok then
+            Log.error('Extension %q failed to initialize: %s', vim.inspect(error))
+          end
         end
       end
     end

--- a/lua/legendary/extensions/init.lua
+++ b/lua/legendary/extensions/init.lua
@@ -1,0 +1,30 @@
+local Log = require('legendary.log')
+
+local M = {}
+
+function M.load_all(extensions)
+  if type(extensions) ~= 'table' then
+    Log.error('config.extensions must be a table; received %s', type(extensions))
+    return
+  end
+
+  for extension_name, extension_config in pairs(extensions) do
+    local load_status, module_or_error = pcall(require, string.format('legendary.extensions.%s', extension_name))
+    if not load_status then
+      Log.error('Error loading extensions %q: %s', vim.inspect(module_or_error))
+    else
+      local module = module_or_error -- now known to not be an error
+      if type(module) ~= 'function' then
+        Log.error('Extension %q does not return a function.', extension_name)
+      else
+        -- module is a function
+        local ok, error = pcall(module, extension_config)
+        if not ok then
+          Log.error('Extension %q failed to initialize: %s', vim.inspect(error))
+        end
+      end
+    end
+  end
+end
+
+return M

--- a/lua/legendary/extensions/init.lua
+++ b/lua/legendary/extensions/init.lua
@@ -2,27 +2,42 @@ local Log = require('legendary.log')
 
 local M = {}
 
-function M.load_all(extensions)
+---Load all extensions specified in legendary.nvim config
+function M.load_all()
+  local extensions = require('legendary.config').extensions
   if type(extensions) ~= 'table' then
     Log.error('config.extensions must be a table; received %s', type(extensions))
     return
   end
 
   for extension_name, extension_config in pairs(extensions) do
-    if extension_config ~= false then
-      local load_status, module_or_error = pcall(require, string.format('legendary.extensions.%s', extension_name))
-      if not load_status then
-        Log.error('Error loading extensions %q: %s', vim.inspect(module_or_error))
+    M.load_extension(extension_name, extension_config)
+  end
+end
+
+---Load a single extension by name. If config is not provided,
+---it will be looked up in the legendary.nvim config.
+---@param extension_name string
+---@param config any
+function M.load_extension(extension_name, config)
+  local extension_config = config
+  if extension_config == nil then
+    extension_config = require('legendary.config').extensions[extension_name]
+  end
+
+  if extension_config ~= false then
+    local load_status, module_or_error = pcall(require, string.format('legendary.extensions.%s', extension_name))
+    if not load_status then
+      Log.error('Error loading extensions %q: %s', vim.inspect(module_or_error))
+    else
+      local module = module_or_error -- now known to not be an error
+      if type(module) ~= 'function' then
+        Log.error('Extension %q does not return a function.', extension_name)
       else
-        local module = module_or_error -- now known to not be an error
-        if type(module) ~= 'function' then
-          Log.error('Extension %q does not return a function.', extension_name)
-        else
-          -- module is a function
-          local ok, error = pcall(module, extension_config)
-          if not ok then
-            Log.error('Extension %q failed to initialize: %s', vim.inspect(error))
-          end
+        -- module is a function
+        local ok, error = pcall(module, extension_config)
+        if not ok then
+          Log.error('Extension %q failed to initialize: %s', vim.inspect(error))
         end
       end
     end

--- a/lua/legendary/extensions/init.lua
+++ b/lua/legendary/extensions/init.lua
@@ -25,20 +25,22 @@ function M.load_extension(extension_name, config)
     extension_config = require('legendary.config').extensions[extension_name]
   end
 
-  if extension_config ~= false then
-    local load_status, module_or_error = pcall(require, string.format('legendary.extensions.%s', extension_name))
-    if not load_status then
-      Log.error('Error loading extensions %q: %s', vim.inspect(module_or_error))
+  if extension_config == false then
+    return
+  end
+
+  local load_status, module_or_error = pcall(require, string.format('legendary.extensions.%s', extension_name))
+  if not load_status then
+    Log.error('Error loading extensions %q: %s', extension_name, vim.inspect(module_or_error))
+  else
+    local module = module_or_error -- now known to not be an error
+    if type(module) ~= 'function' then
+      Log.error('Extension %q does not return a function.', extension_name)
     else
-      local module = module_or_error -- now known to not be an error
-      if type(module) ~= 'function' then
-        Log.error('Extension %q does not return a function.', extension_name)
-      else
-        -- module is a function
-        local ok, error = pcall(module, extension_config)
-        if not ok then
-          Log.error('Extension %q failed to initialize: %s', vim.inspect(error))
-        end
+      -- module is a function
+      local ok, error = pcall(module, extension_config)
+      if not ok then
+        Log.error('Extension %q failed to initialize: %s', extension_name, vim.inspect(error))
       end
     end
   end

--- a/lua/legendary/extensions/nvim_tree.lua
+++ b/lua/legendary/extensions/nvim_tree.lua
@@ -9,6 +9,13 @@ local function init()
     }
   end, keymaps)
   require('legendary').keymaps(legendary_keymaps)
+  require('legendary').commands({
+    { 'NvimTreeOpen', description = 'nvim-tree: Open file tree' },
+    { 'NvimTreeClose', description = 'nvim-tree: Close file tree' },
+    { 'NvimTreeToggle', description = 'nvim-tree: Toggle file tree' },
+    { 'NvimTreeFocus', description = 'nvim-tree: Focus window' },
+    { 'NvimTreeRefresh', description = 'nvim-tree: Refresh file tree' },
+  })
 end
 
 return function()

--- a/lua/legendary/extensions/nvim_tree.lua
+++ b/lua/legendary/extensions/nvim_tree.lua
@@ -9,6 +9,7 @@ local function init()
     }
   end, keymaps)
   require('legendary').keymaps(legendary_keymaps)
+  -- TODO update once this is resolved: https://github.com/nvim-tree/nvim-tree.lua/issues/2076
   require('legendary').commands({
     { 'NvimTreeOpen', description = 'nvim-tree: Open file tree' },
     { 'NvimTreeClose', description = 'nvim-tree: Close file tree' },

--- a/lua/legendary/extensions/nvim_tree.lua
+++ b/lua/legendary/extensions/nvim_tree.lua
@@ -1,0 +1,25 @@
+local function init()
+  local keymaps = require('nvim-tree.api').config.mappings.get_keymap()
+  local legendary_keymaps = vim.tbl_map(function(keymap)
+    return {
+      keymap.lhs,
+      description = keymap.desc,
+      mode = keymap.mode,
+      filters = { filetype = 'NvimTree' },
+    }
+  end, keymaps)
+  require('legendary').keymaps(legendary_keymaps)
+end
+
+return function()
+  -- check if nvim-tree has already been loaded
+  if vim.g.NvimTreeRequired and vim.g.NvimTreeSetup then
+    init()
+  else
+    vim.api.nvim_create_autocmd('User', {
+      pattern = 'NvimTreeSetup',
+      callback = init,
+      once = true,
+    })
+  end
+end

--- a/lua/legendary/init.lua
+++ b/lua/legendary/init.lua
@@ -23,6 +23,7 @@ local ItemGroup = Lazy.require_on_exported_call('legendary.data.itemgroup')
 ---@type LegendaryLogger
 local Log = Lazy.require_on_exported_call('legendary.log')
 
+local Extensions = Lazy.require_on_exported_call('legendary.extensions')
 local LegendaryWhichKey = Lazy.require_on_index('legendary.integrations.which-key')
 
 ---@param parser LegendaryItem
@@ -95,6 +96,10 @@ function M.setup(cfg)
   M.commands(Config.commands)
   M.autocmds(Config.autocmds)
   M.itemgroups(Config.itemgroups)
+
+  if #vim.tbl_keys(Config.extensions) > 0 then
+    Extensions.load_all(Config.extensions)
+  end
 
   Log.trace('setup() parsed and applied all configuration.')
 end

--- a/lua/legendary/init.lua
+++ b/lua/legendary/init.lua
@@ -98,7 +98,7 @@ function M.setup(cfg)
   M.itemgroups(Config.itemgroups)
 
   if #vim.tbl_keys(Config.extensions) > 0 then
-    Extensions.load_all(Config.extensions)
+    Extensions.load_all()
   end
 
   Log.trace('setup() parsed and applied all configuration.')


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #183 

## How to Test

1. Load the plugin from this branch, and setup with `require('legendary').setup({ extensions = { nvim_tree = true } })`
2. Make sure nvim-tree is installed
3. Open nvim-tree
4. Trigger the legendary.nvim finder from the nvim-tree window
5. It should show the nvim-tree keymaps
6. Triggering the legendary.nvim finder from _any other window_ should _not_ show the nvim-tree keymaps

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
