### PR TITLE
fix: `Config.which_key.mappings` are now registered properly

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -28,3 +28,5 @@ jobs:
             itemgroups
             api
             frecency
+            which-key
+            extension

--- a/lua/legendary/init.lua
+++ b/lua/legendary/init.lua
@@ -87,7 +87,7 @@ function M.setup(cfg)
     LegendaryWhichKey.whichkey_listen()
   end
 
-  if #Config.which_key.mappings > 0 then
+  if #vim.tbl_keys(Config.which_key.mappings) > 0 then
     LegendaryWhichKey.bind_whichkey(Config.which_key.mappings, Config.which_key.opts, Config.which_key.do_binding)
   end
 


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #323 

## How to Test

1. Which-key mappings like this should be picked up

```lua
require('legendary').setup({
  which_key = {
    mappings = {
      ['<space>f'] = {
        function()
          print('foo')
        end,
        'Print foo',
      },
    },
  },
})
```

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
