### PR TITLE
feat(extension): add smart-splits.nvim extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ require('legendary').setup({
   -- initializing the extension.
   extensions = {
     nvim_tree = false,
+    smart_splits = false,
   },
   scratchpad = {
     -- How to open the scratchpad buffer,

--- a/doc/EXTENSIONS.md
+++ b/doc/EXTENSIONS.md
@@ -43,3 +43,15 @@ require('legendary').setup({
   },
 })
 ```
+
+## `smart-splits.nvim`
+
+Automatically load commands from `smart-splits.nvim`.
+
+```lua
+require('legendary').setup({
+  extensions = {
+    smart_splits = true,
+  },
+})
+```

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -108,9 +108,7 @@ local config = {
   -- be a single function. Extensions are modules under `legendary.extensions.*`
   -- which return a single function, which is responsible for loading and
   -- initializing the extension.
-  extensions = {
-    nvim_tree = false,
-  },
+  extensions = {},
   scratchpad = {
     -- How to open the scratchpad buffer,
     -- 'current' for current window, 'float'

--- a/lua/legendary/extensions/smart_splits.lua
+++ b/lua/legendary/extensions/smart_splits.lua
@@ -1,0 +1,22 @@
+return function()
+  local autocmd_id
+  autocmd_id = vim.api.nvim_create_autocmd('User', {
+    pattern = 'LegendaryUiPre',
+    callback = function()
+      local ok, cmds = pcall(require, 'smart-splits.commands')
+      if not ok then
+        return
+      end
+
+      local legendary_commands = vim.tbl_map(function(cmd)
+        return {
+          cmd[1],
+          description = cmd[3].desc,
+        }
+      end, cmds)
+      require('legendary').commands(legendary_commands)
+      -- once we've got the commands registered, stop looking for them
+      vim.api.nvim_del_autocmd(autocmd_id)
+    end,
+  })
+end

--- a/lua/legendary/ui/init.lua
+++ b/lua/legendary/ui/init.lua
@@ -98,6 +98,7 @@ end
 ---Select an item
 ---@param opts LegendaryFindOpts
 function M.select(opts)
+  vim.cmd('doautocmd User LegendaryUiPre')
   local context = Executor.build_context()
   select_inner(opts, context)
 end


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

## How to Test

1. Install `smart-splits.nvim` and enable extension
2. Commands should be loaded into legendary

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
