### PR TITLE
feat: add op.nvim extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ require('legendary').setup({
   extensions = {
     nvim_tree = false,
     smart_splits = false,
+    op_nvim = false,
   },
   scratchpad = {
     -- How to open the scratchpad buffer,

--- a/doc/EXTENSIONS.md
+++ b/doc/EXTENSIONS.md
@@ -4,6 +4,8 @@
 
 - [Extensions](#extensions)
   - [`nvim-tree.lua`](#nvim-treelua)
+  - [`smart-splits.nvim`](#smart-splitsnvim)
+  - [`op.nvim`](#opnvim)
 
 <!--toc:end-->
 
@@ -52,6 +54,18 @@ Automatically load commands from `smart-splits.nvim`.
 require('legendary').setup({
   extensions = {
     smart_splits = true,
+  },
+})
+```
+
+## `op.nvim`
+
+Automatically load commands from `op.nvim`.
+
+```lua
+require('legendary').setup({
+  extensions = {
+    op_nvim = true,
   },
 })
 ```

--- a/lua/legendary/extensions/op_nvim.lua
+++ b/lua/legendary/extensions/op_nvim.lua
@@ -1,0 +1,22 @@
+return function()
+  local autocmd_id
+  autocmd_id = vim.api.nvim_create_autocmd('User', {
+    pattern = 'LegendaryUiPre',
+    callback = function()
+      local ok, cmds = pcall(require, 'op.commands')
+      if not ok then
+        return
+      end
+
+      local legendary_commands = vim.tbl_map(function(cmd)
+        return {
+          cmd[1],
+          description = cmd[3].desc,
+        }
+      end, cmds)
+      require('legendary').commands(legendary_commands)
+      -- once we've got the commands registered, stop looking for them
+      vim.api.nvim_del_autocmd(autocmd_id)
+    end,
+  })
+end


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

## How to Test

1. Install `op.nvim`
2. Commands should be loaded into legendary when you trigger the UI

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
