### PR TITLE
fix(ui): Normalize type of `opts.pattern` for autocmds in UI

### DIFF
--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -166,6 +166,7 @@ local config = {
 ---@field default_opts LegendaryDefaultOptsConfig
 ---@field select_prompt string|fun():string
 ---@field col_separator_char string
+---@field icons table<string, string>
 ---@field default_item_formatter LegendaryItemFormatter
 ---@field include_builtin boolean
 ---@field include_legendary_cmds boolean

--- a/lua/legendary/ui/format.lua
+++ b/lua/legendary/ui/format.lua
@@ -17,7 +17,7 @@ end
 function M.default_format(item)
   if Toolbox.is_keymap(item) then
     return {
-      Config.icons.keymap or table.concat(item:modes(), ', '),
+      Config.icons.keymap or table.concat(item--[[@as Keymap]]:modes(), ', '),
       item.keys,
       item.description,
     }
@@ -28,9 +28,13 @@ function M.default_format(item)
       item.description,
     }
   elseif Toolbox.is_autocmd(item) then
+    local pattern = vim.tbl_get(item, 'opts', 'pattern') or { '*' }
+    if type(pattern) == 'string' then
+      pattern = { pattern }
+    end
     return {
       table.concat(item.events, ', '),
-      table.concat(vim.tbl_get(item, 'opts', 'pattern') or { '*' }, ', '),
+      table.concat(pattern, ', '),
       item.description,
     }
   elseif Toolbox.is_function(item) then


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #331 

## How to Test

1. Create the item described in the issue
2. Launch the UI

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
