### PR TITLE
feat(extension): implement extension for diffview.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ require('legendary').setup({
     smart_splits = true,
     -- load commands from op.nvim
     op_nvim = true,
+    -- load keymaps from diffview.nvim
+    diffview = true,
   },
 })
 ```
@@ -368,6 +370,7 @@ require('legendary').setup({
     nvim_tree = false,
     smart_splits = false,
     op_nvim = false,
+    diffview = false,
   },
   scratchpad = {
     -- How to open the scratchpad buffer,

--- a/lua/legendary/extensions/diffview.lua
+++ b/lua/legendary/extensions/diffview.lua
@@ -1,0 +1,61 @@
+local function parse_keymaps(keymaps, filters)
+  local mappings = {}
+  for _, keymap in ipairs(keymaps) do
+    local desc = vim.tbl_get(keymap, 4, 'desc')
+    if desc and #desc > 0 and desc ~= 'diffview_ignore' then
+      table.insert(mappings, {
+        keymap[2],
+        description = string.format('Diffview: %s', desc),
+        mode = keymap[1],
+        filters = filters,
+      })
+    end
+  end
+  return mappings
+end
+
+local function diffview_is_open()
+  return require('diffview.lib').get_current_view() ~= nil
+end
+
+local function diffview_type_matches(type)
+  return function()
+    local view = require('diffview.lib').get_current_view()
+    return view ~= nil and vim.startswith(view.cur_layout.name, type)
+  end
+end
+
+return function()
+  require('legendary.extensions').pre_ui_hook(function()
+    -- we need to wait until the user has applied their own config.
+    -- as a best approximation, we can wait until `diffview` has been loaded
+    if not package.loaded['diffview'] then
+      return false
+    end
+
+    local ok, diffview_cfg = pcall(require, 'diffview.config')
+    if not ok then
+      return false
+    end
+
+    local keymaps = diffview_cfg.get_config().keymaps
+    local legendary_keymaps = {}
+    for key, mappings in pairs(keymaps) do
+      if key == 'option_panel' or key == 'help_panel' or key == 'disable_defaults' then
+        -- no op
+      elseif key == 'view' then -- these apply to all diffview view types
+        legendary_keymaps = vim.list_extend(legendary_keymaps, parse_keymaps(mappings, { diffview_is_open }))
+      elseif key == 'file_panel' then
+        legendary_keymaps = vim.list_extend(legendary_keymaps, parse_keymaps(mappings, { filetype = 'DiffviewFiles' }))
+      elseif key == 'file_history_panel' then
+        legendary_keymaps =
+          vim.list_extend(legendary_keymaps, parse_keymaps(mappings, { filetype = 'DiffviewFileHistory' }))
+      else
+        -- e.g. the layout name will be "diff2_horizontal"
+        legendary_keymaps = vim.list_extend(legendary_keymaps, parse_keymaps(mappings, { diffview_type_matches(key) }))
+      end
+    end
+    require('legendary').keymaps(legendary_keymaps)
+    return true
+  end)
+end

--- a/lua/legendary/extensions/diffview.lua
+++ b/lua/legendary/extensions/diffview.lua
@@ -41,16 +41,14 @@ return function()
     local keymaps = diffview_cfg.get_config().keymaps
     local legendary_keymaps = {}
     for key, mappings in pairs(keymaps) do
-      if key == 'option_panel' or key == 'help_panel' or key == 'disable_defaults' then
-        -- no op
-      elseif key == 'view' then -- these apply to all diffview view types
+      if key == 'view' then -- these apply to all diffview view types
         legendary_keymaps = vim.list_extend(legendary_keymaps, parse_keymaps(mappings, { diffview_is_open }))
       elseif key == 'file_panel' then
         legendary_keymaps = vim.list_extend(legendary_keymaps, parse_keymaps(mappings, { filetype = 'DiffviewFiles' }))
       elseif key == 'file_history_panel' then
         legendary_keymaps =
           vim.list_extend(legendary_keymaps, parse_keymaps(mappings, { filetype = 'DiffviewFileHistory' }))
-      else
+      elseif key ~= 'option_panel' and key ~= 'help_panel' and key ~= 'disable_defaults' then
         -- e.g. the layout name will be "diff2_horizontal"
         legendary_keymaps = vim.list_extend(legendary_keymaps, parse_keymaps(mappings, { diffview_type_matches(key) }))
       end

--- a/lua/legendary/extensions/diffview.lua
+++ b/lua/legendary/extensions/diffview.lua
@@ -56,6 +56,13 @@ return function()
       end
     end
     require('legendary').keymaps(legendary_keymaps)
+    require('legendary').commands({
+      { ':DiffviewOpen', description = 'Open diffview.nvim view' },
+      { ':DiffviewClose', description = 'Close diffview.nvim view' },
+      { ':DiffviewToggleFiles', description = 'Toggle the files panel of diffview.nvim view' },
+      { ':DiffviewFocusFiles', description = 'Move cursor to diffview.nvim files buffer' },
+      { ':DiffviewRefresh', description = 'Refresh diffview.nvim view' },
+    })
     return true
   end)
 end

--- a/lua/legendary/extensions/op_nvim.lua
+++ b/lua/legendary/extensions/op_nvim.lua
@@ -2,7 +2,7 @@ return function()
   require('legendary.extensions').pre_ui_hook(function()
     local ok, cmds = pcall(require, 'op.commands')
     if not ok then
-      return
+      return false
     end
 
     local legendary_commands = vim.tbl_map(function(cmd)

--- a/lua/legendary/extensions/smart_splits.lua
+++ b/lua/legendary/extensions/smart_splits.lua
@@ -2,7 +2,7 @@ return function()
   require('legendary.extensions').pre_ui_hook(function()
     local ok, cmds = pcall(require, 'smart-splits.commands')
     if not ok then
-      return
+      return false
     end
 
     local legendary_commands = vim.tbl_map(function(cmd)


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #338 

## How to Test

```lua
require('legendary').setup({
  extensions = {
    diffview = true,
  },
})
```

Run `:DiffviewOpen`. Commands from `diffview.nvim` should now all appear in `legendary.nvim`, and keymaps from `diffview.nvim` should appear, filtered by the correct view type, e.g. `diff2` keymaps should only show up on the `diff2` view.

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
