### PR TITLE
feat(api): filters can now be applied to all item types instead of just keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ require('legendary').setup({
         -- more keymaps here
       },
     },
+    -- in-place filters, see :h legendary-tables or ./doc/table_structures/README.md
+    { '<leader>m', description = 'Preview markdown', filters = { ft = 'markdown' } },
   },
   commands = {
     -- easily create user commands
@@ -146,6 +148,8 @@ require('legendary').setup({
         -- more commands here
       },
     },
+    -- in-place filters, see :h legendary-tables or ./doc/table_structures/README.md
+    { ':Glow', description = 'Preview markdown', filters = { ft = 'markdown' } },
   },
   funcs = {
     -- Make arbitrary Lua functions that can be executed via the item finder

--- a/doc/table_structures/KEYMAPS.md
+++ b/doc/table_structures/KEYMAPS.md
@@ -167,30 +167,6 @@ local keymaps = {
 }
 ```
 
-## In-place special filters
-
-Sometimes, you need to add special filters to keymaps. One example where this is useful is when other plugins create
-keymaps that are only active in buffers managed by that plugin (e.g. `nvim-tree.lua` keymaps are only active in the
-`nvimtree` buffer). There are two special filters, `buftype` and `filetype` that may be specified directly, and you
-can also pass custom functions under the `filters` property. Functions receive the item and the editor context
-as parameters.
-
-```lua
-local keymaps = {
-  {
-    '<C-v>',
-    description = 'Open file in new vertical split',
-    filters = {
-      filetype = 'NvimTree', -- can also be a list of filetypes, { 'NvimTree', 'NeoTree' }
-      buftype = 'nofile', -- can also be a list of buftypes, { 'nofile', 'acwrite' }
-      function(item, context) -- custom function filter
-        return context.mode == 'n'
-      end,
-    },
-  },
-}
-```
-
 ## Item groups
 
 You can also organize keymaps, commands, and functions into groups that will show up

--- a/doc/table_structures/README.md
+++ b/doc/table_structures/README.md
@@ -18,3 +18,57 @@ documentation on accepted types.
 - [Commands](./COMMANDS.md)
 - [Functions](./FUNCTIONS.md)
 - [`augroup`/`autocmd`s](./AUTOCMDS.md)
+
+## In-Place Item Filters
+
+All items also support a special in-place filtering syntax, so the item can define its own filter.
+The `filters` property should be a table defining one or more filters. The table supports
+special properties `bt = value` or `buftype = value` to automatically filter by buffer type,
+and `ft = value` or `filetype = value` to automatically filter by file type. You may also
+include custom filter functions in the `filters` table as a list. For example:
+
+```lua
+local keymaps = {
+  { '<C-v>', description = 'Open in vertical split', filters = { ft = 'NvimTree' } },
+  {
+    '<leader>qt',
+    description = 'Do something',
+    filters = {
+      ft = 'Markdown',
+      function(item, context)
+        -- here, item is the parsed item itself,
+        -- context is a context object, see "Filter Context" below
+        return myCustomLogic(context)
+      end,
+    },
+  },
+}
+
+local commands = {
+  { ':Glow', description = 'Preview Markdown with Glow', filters = { ft = 'markdown' } },
+  {
+    ':Something',
+    description = 'Do something',
+    filters = {
+      function(item, context)
+        -- same function signature as keymaps
+      end,
+    },
+  },
+}
+```
+
+### Filter Context
+
+The `context` table passed to filters contains the following properties:
+
+```lua
+{
+  buf = number, -- buffer ID
+  buftype = string,
+  filetype = string,
+  mode = string, -- the mode that the UI was triggered from
+  cursor_pos = table, -- { row, col }
+  marks = table, -- visual mode marks, if applicable; { line, col, line, col }
+}
+```

--- a/lua/legendary/data/autocmd.lua
+++ b/lua/legendary/data/autocmd.lua
@@ -1,6 +1,7 @@
 local class = require('legendary.vendor.middleclass')
 local util = require('legendary.util')
 local Config = require('legendary.config')
+local Filters = require('legendary.data.filters')
 
 ---@class Autocmd
 ---@field events string[]
@@ -10,6 +11,7 @@ local Config = require('legendary.config')
 ---@field group string|integer|nil
 ---@field class Autocmd
 local Autocmd = class('Autocmd')
+Autocmd:include(Filters) ---@diagnostic disable-line
 
 ---Parse a new autocmd table
 ---@param tbl table
@@ -33,6 +35,7 @@ function Autocmd:parse(tbl) -- luacheck: no unused
   instance.description = util.get_desc(tbl)
   instance.group = tbl.group
   instance.hide = util.bool_default(tbl.hide, false)
+  instance:parse_filters(tbl.filters)
 
   return instance
 end

--- a/lua/legendary/data/command.lua
+++ b/lua/legendary/data/command.lua
@@ -1,6 +1,7 @@
 local class = require('legendary.vendor.middleclass')
 local util = require('legendary.util')
 local Config = require('legendary.config')
+local Filters = require('legendary.data.filters')
 local Toolbox = require('legendary.toolbox')
 
 ---@class ModeCommand
@@ -20,9 +21,11 @@ local Toolbox = require('legendary.toolbox')
 ---@field description string
 ---@field opts table
 ---@field unfinished boolean
+---@field filters (function[])|nil
 ---@field builtin boolean
 ---@field class Command
 local Command = class('Command')
+Command:include(Filters) ---@diagnostic disable-line
 
 local function exec(impl, args)
   if type(impl) == 'string' then
@@ -96,6 +99,7 @@ function Command:parse(tbl, builtin) -- luacheck: no unused
 
     instance.implementation = parse_modemap(instance.implementation)
   end
+  instance:parse_filters(tbl.filters)
 
   return instance
 end

--- a/lua/legendary/data/filters.lua
+++ b/lua/legendary/data/filters.lua
@@ -1,0 +1,64 @@
+local function buftype_filter(value)
+  return function(_, context)
+    if type(value) == 'string' then
+      return context.buftype == value
+    else
+      for _, value_inner in ipairs(value) do
+        if context.buftype ~= value_inner then
+          return false
+        end
+      end
+      return true
+    end
+  end
+end
+
+local function filetype_filter(value)
+  return function(_, context)
+    if type(value) == 'string' then
+      return context.filetype == value
+    else
+      for _, value_inner in ipairs(value) do
+        if context.filetype ~= value_inner then
+          return false
+        end
+      end
+      return true
+    end
+  end
+end
+
+---A middleclass class mixin to parse filters
+local M = {}
+
+---Take the filters input and return a list of filter functions
+---Also sets self.filters to the result
+---@param filters table
+---@return (function[])|nil
+function M.parse_filters(self, filters)
+  if not filters then
+    return nil
+  end
+
+  local result = {}
+
+  for key, value in pairs(filters) do
+    -- check special keys
+    if key == 'buftype' or key == 'bt' then
+      table.insert(result, buftype_filter(value))
+    end
+    if key == 'filetype' or key == 'ft' then
+      table.insert(result, filetype_filter(value))
+    end
+
+    -- then list items
+    if type(key) == 'number' and type(value) == 'function' then
+      table.insert(result, value)
+    end
+  end
+
+  self.filters = result
+  return result
+end
+
+return M

--- a/lua/legendary/data/function.lua
+++ b/lua/legendary/data/function.lua
@@ -1,12 +1,15 @@
 local class = require('legendary.vendor.middleclass')
 local util = require('legendary.util')
+local Filters = require('legendary.data.filters')
 
 ---@class Function
 ---@field implementation function
 ---@field description string
 ---@field opts table
+---@field filters (function[])|nil
 ---@field class Function
 local Function = class('Function')
+Function:include(Filters) ---@diagnostic disable-line
 
 function Function:parse(tbl) -- luacheck: no unused
   vim.validate({
@@ -20,6 +23,7 @@ function Function:parse(tbl) -- luacheck: no unused
   instance.implementation = tbl[1]
   instance.description = util.get_desc(tbl)
   instance.opts = tbl.opts or {}
+  instance:parse_filters(tbl.filters)
 
   return instance
 end

--- a/lua/legendary/data/itemgroup.lua
+++ b/lua/legendary/data/itemgroup.lua
@@ -3,14 +3,17 @@ local ItemList = require('legendary.data.itemlist')
 local Keymap = require('legendary.data.keymap')
 local Command = require('legendary.data.command')
 local Function = require('legendary.data.function')
+local Filters = require('legendary.data.filters')
 
 ---@class ItemGroup
 ---@field name string
 ---@field items ItemList
 ---@field icon string|nil
 ---@field description string|nil
+---@field filters (function[])|nil
 ---@field class ItemGroup
 local ItemGroup = class('ItemGroup')
+ItemGroup:include(Filters) ---@diagnostic disable-line
 
 ---Parse an ItemGroup
 ---@param tbl table
@@ -30,6 +33,7 @@ function ItemGroup:parse(tbl) -- luacheck: no unused
   instance.icon = tbl.icon
   instance.description = tbl.description
   instance.items = ItemList:create()
+  instance:parse_filters(tbl.filters)
 
   local keymaps = vim.tbl_map(function(keymap)
     return Keymap:parse(keymap)

--- a/lua/legendary/data/itemlist.lua
+++ b/lua/legendary/data/itemlist.lua
@@ -83,9 +83,9 @@ function ItemList:filter(filters, context)
     return vim.tbl_filter(function(item)
       -- NOTE: The creation of a new list via vim.list_extend is important here,
       -- otherwise the list gets added to for every item we filter
-      local all_filters = vim.list_extend({}, filters)
+      local all_filters = vim.list_extend({}, filters, 1, #filters)
       if item.filters then
-        all_filters = vim.list_extend(all_filters, item.filters)
+        all_filters = vim.list_extend(all_filters, item.filters, 1, #item.filters)
       end
 
       return util.tbl_all(all_filters, function(filter)


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #346 

## How to Test

1. Create an item of each type with the `filters` property set
2. Ensure the filters work as expected

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
