### PR TITLE
fix(scratchpad): Attach Lua LSP to buffer when entering scratchpad buf

### DIFF
--- a/lua/legendary/ui/scratchpad.lua
+++ b/lua/legendary/ui/scratchpad.lua
@@ -169,6 +169,13 @@ function M.open(method)
   else
     float(scratchpad_buf_id, { width = math.floor(vim.o.columns * 0.85), height = math.floor(vim.o.lines * 0.85) })
   end
+
+  vim.schedule_wrap(function()
+    -- if using lspconfig, start lua_lsp
+    if vim.fn.exists(':LspStart') ~= 0 then
+      vim.cmd(':LspStart lua_ls')
+    end
+  end)
 end
 
 ---Close the scratchpad buffer


### PR DESCRIPTION


Resolves: #358 

## How to Test

1. Open scratchpad buffer with lspconfig and lua_ls configured
2. lua_ls should attach to the buffer

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
