### PR TITLE
feat(which-key): Add option to not group items when parsing which-key.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ require('legendary').setup({
     -- or if you want to let which-key.nvim handle the bindings.
     -- if not passed, true by default
     do_binding = true,
+    -- controls whether to use legendary.nvim item groups
+    -- matching your which-key.nvim groups; if false, all keymaps
+    -- are added at toplevel instead of in a group.
+    use_groups = true,
   },
   -- Which extensions to load; no extensions are loaded by default.
   -- Setting the plugin name to `false` disables loading the extension.

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -100,6 +100,10 @@ local config = {
     -- or if you want to let which-key.nvim handle the bindings.
     -- if not passed, true by default
     do_binding = true,
+    -- controls whether to use legendary.nvim item groups
+    -- matching your which-key.nvim groups; if false, all keymaps
+    -- are added at toplevel instead of in a group.
+    use_groups = true,
   },
   -- Which extensions to load; no extensions are loaded by default.
   -- Setting the plugin name to `false` disables loading the extension.
@@ -134,6 +138,7 @@ local config = {
 ---@field mappings table[]
 ---@field opts table
 ---@field do_binding boolean
+---@field use_groups boolean
 
 ---@class LegendaryScratchpadConfig
 ---@field view 'float'|'current'

--- a/lua/legendary/integrations/which-key.lua
+++ b/lua/legendary/integrations/which-key.lua
@@ -3,6 +3,7 @@
 local State = require('legendary.data.state')
 local Keymap = require('legendary.data.keymap')
 local Log = require('legendary.log')
+local Config = require('legendary.config')
 
 local Lazy = require('legendary.vendor.lazy')
 ---@type ItemGroup
@@ -33,11 +34,11 @@ local function wk_to_legendary(wk, wk_opts, wk_groups)
   if wk_opts and wk_opts.mode then
     legendary.mode = wk_opts.mode
   end
-  if wk.group == true and #wk.name > 0 then
+  if wk.group == true and #wk.name > 0 and Config.which_key.use_groups then
     legendary.itemgroup = wk.name
   end
-  local group = longest_matching_group(wk, wk_groups)
-  if group then
+  local group = Config.which_key.use_groups and longest_matching_group(wk, wk_groups) or nil
+  if group and Config.which_key.use_groups then
     legendary.itemgroup = group
   end
   legendary.description = wk.label or vim.tbl_get(wk, 'opts', 'desc')


### PR DESCRIPTION
…nvim tbls

<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #372 

## How to Test

1. Have which-key config with groups
2. Enable which-key integration
3. `require('legendary').setup({ which_key = {  use_groups = false  } })`
4. legendary.nvim should not create item groups from the which-key groups

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
