### PR TITLE
fix(api): Fix incorrect adjustment of visual mode marks

### DIFF
--- a/lua/legendary/toolbox.lua
+++ b/lua/legendary/toolbox.lua
@@ -164,12 +164,7 @@ function M.get_marks()
   local cursor = vim.api.nvim_win_get_cursor(0)
   local cline, ccol = cursor[1], cursor[2]
   local vline, vcol = vim.fn.line('v'), vim.fn.col('v')
-  if ccol > vcol then
-    local swap = vcol
-    vcol = ccol + 1
-    ccol = swap
-  end
-  return { cline, ccol, vline, vcol }
+  return { vline, vcol, cline, ccol + 1 }
 end
 
 ---Set visual marks from a table in the format


### PR DESCRIPTION
Resolves: #376

## How to Test

Use the instructions provided in the issue

## Testing for Regressions

I have tested the following:

- [ ] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [ ] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [ ] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [ ] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [ ] `augroup`/`autocmd`s created through `legendary.nvim` work correctly