### PR TITLE
feat(keymaps): Execute builtin keymaps without remapping

### DIFF
--- a/lua/legendary/api/executor.lua
+++ b/lua/legendary/api/executor.lua
@@ -74,7 +74,7 @@ function M.exec_item(item, context)
           vim.cmd(cmd)
         end
       elseif Toolbox.is_keymap(item) then
-        util.exec_feedkeys(item.keys)
+        util.exec_feedkeys(item.keys, item.builtin)
       elseif Toolbox.is_autocmd(item) then
         local impl = item.implementation
         if type(impl) == 'function' then

--- a/lua/legendary/util.lua
+++ b/lua/legendary/util.lua
@@ -60,8 +60,12 @@ end
 ---Execute the given keys via `vim.api.nvim_feedkeys`,
 ---`keys` are escaped using `vim.api.nvim_replace_termcodes`
 ---@param keys string
-function M.exec_feedkeys(keys)
-  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(keys, true, false, true), 't', true)
+function M.exec_feedkeys(keys, noremap)
+  local mode = 't'
+  if noremap then
+    mode = mode .. 'n'
+  end
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(keys, true, false, true), mode, true)
 end
 
 ---Run the given function, timing it's duration and logging the performance


### PR DESCRIPTION
Resolves: #379

## How to Test

1. Create a keymap that replaces a builtin keymap, like `gg` (First Line)
2. Call Legendary and select the builtin keymap

## Testing for Regressions

I have tested the following:

- [ ] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [ ] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [ ] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [ ] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [ ] `augroup`/`autocmd`s created through `legendary.nvim` work correctly

**Remarks**

I've testet this with my configuration (mostly functions, some anonymous keymaps, no commands or auto...)