### PR TITLE
feat(integrations): Optionally autoload keymaps from lazy.nvim plugin specs

### DIFF
--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -87,6 +87,11 @@ local config = {
       max_timestamps = 10,
     },
   },
+  lazy_nvim = {
+    -- Automatically register keymaps that are defined on lazy.nvim plugin specs
+    -- using the `keys = {}` property.
+    auto_register = false,
+  },
   which_key = {
     -- Automatically add which-key tables to legendary
     -- see ./doc/WHICH_KEY.md for more details
@@ -133,6 +138,9 @@ local config = {
   log_level = 'info',
 }
 
+---@class LegendaryLazyNvimConfig
+---@field auto_register boolean
+
 ---@class LegendaryWhichkeyConfig
 ---@field auto_register boolean
 ---@field mappings table[]
@@ -176,6 +184,7 @@ local config = {
 ---@field include_builtin boolean
 ---@field include_legendary_cmds boolean
 ---@field sort LegendarySortOpts
+---@field lazy_nvim LegendaryLazyNvimConfig
 ---@field which_key LegendaryWhichkeyConfig
 ---@field extensions table<string, any>
 ---@field scratchpad LegendaryScratchpadConfig

--- a/lua/legendary/init.lua
+++ b/lua/legendary/init.lua
@@ -24,6 +24,7 @@ local ItemGroup = Lazy.require_on_exported_call('legendary.data.itemgroup')
 local Log = Lazy.require_on_exported_call('legendary.log')
 
 local Extensions = Lazy.require_on_exported_call('legendary.extensions')
+local LegendaryLazyNvim = Lazy.require_on_index('legendary.integrations.lazy-nvim')
 local LegendaryWhichKey = Lazy.require_on_index('legendary.integrations.which-key')
 
 ---@param parser LegendaryItem
@@ -83,6 +84,10 @@ end
 
 function M.setup(cfg)
   Config.setup(cfg)
+
+  if Config.lazy_nvim.auto_register then
+    LegendaryLazyNvim.load_lazy_nvim_keys()
+  end
 
   if Config.which_key.auto_register then
     LegendaryWhichKey.whichkey_listen()

--- a/lua/legendary/integrations/lazy-nvim.lua
+++ b/lua/legendary/integrations/lazy-nvim.lua
@@ -1,0 +1,33 @@
+local Log = require('legendary.log')
+
+local M = {}
+
+function M.load_lazy_nvim_keys()
+  local has_lazy, _ = pcall(require, 'lazy')
+  if not has_lazy then
+    Log.warn("lazy.nvim integration is enabled, but cannot `require('lazy')`, aborting.")
+    return
+  end
+
+  local LazyNvimConfig = require('lazy.core.config')
+  local Handler = require('lazy.core.handler')
+  for _, plugin in pairs(LazyNvimConfig.plugins) do
+    local keys = Handler.handlers.keys:values(plugin)
+    for _, keymap in pairs(keys) do
+      if keymap.desc and #keymap.desc > 0 then
+        -- we don't need the implementation, since
+        -- lazy.nvim will have already bound it. We
+        -- just need the description-only item to appear
+        -- in the legendary.nvim finder.
+        local legendary_keymap = {
+          keymap[1], -- lhs
+          description = keymap.desc,
+          mode = keymap.mode, ---@type string|string[]|nil
+        }
+        require('legendary').keymap(legendary_keymap)
+      end
+    end
+  end
+end
+
+return M


### PR DESCRIPTION


<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #377 

## How to Test

1. Setup `legendary.nvim` with `require('legendary').setup({ lazy_nvim = { auto_register = true } })`
2. Set up a keymap through a lazy.nvim plugin spec like

```lua
{
  'folke/flash.nvim',
  keys = {
    {
      's',
      function()
        require('flash').jump()
      end,
      mode = { 'n', 'x', 'o' },
      desc = 'Jump forwards',
    },
    {
      'S',
      function()
        require('flash').jump({ search = { forward = false } })
      end,
      mode = { 'n', 'x', 'o' },
      desc = 'Jump backwards',
    },
  },
}
```
3. The keymaps defined in the plugin spec should be loaded into legendary.nvim

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
