### PR TITLE
feat(api): Add command + API to repeat last selected item

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ Commands:
 
 " search autocmds
 :Legendary autocmds
+
+" repeat the last item executed via legendary.nvim's finder
+:LegendaryRepeat
 ```
 
 Lua API:

--- a/README.md
+++ b/README.md
@@ -262,8 +262,12 @@ Commands:
 " search autocmds
 :Legendary autocmds
 
-" repeat the last item executed via legendary.nvim's finder
+" repeat the last item executed via legendary.nvim's finder;
+" by default, only executes if the last set of item filters used still returns `true`
 :LegendaryRepeat
+
+" repeat the last item executed via legendary.nvim's finder, ignoring the filters used
+:LegendaryRepeat!
 ```
 
 Lua API:

--- a/doc/API.md
+++ b/doc/API.md
@@ -91,7 +91,7 @@ require('legendary').find({
 })
 -- filter keymaps by normal mode
 require('legendary').find({
-  filters = require('legendary.filters').mode('n')
+  filters = require('legendary.filters').mode('n'),
 })
 -- filter keymaps by normal mode and that start with <leader>
 require('legendary').find({
@@ -99,9 +99,17 @@ require('legendary').find({
     require('legendary.filters').mode('n'),
     function(item)
       return require('legendary.toolbox').is_keymap(item) and vim.startswith(item[1], '<leader>')
-    end
-  }
+    end,
+  },
 })
+```
+
+## Repeat Last Item
+
+You can repeat the previous item selected from `legendary.nvim`'s finder like so:
+
+```lua
+require('legendary').repeat_previous()
 ```
 
 ## Converting Keymaps From Vimscript
@@ -112,20 +120,18 @@ Keymaps can be parsed from Vimscript commands (e.g. `vnoremap <silent> <leader>f
 -- Function signature
 require('legendary.toolbox').table_from_vimscript(vimscript_str, description)
 -- For example
-require('legendary.toolbox').table_from_vimscript(
-  ':vnoremap <silent> <expr> <leader>f :SomeCommand<CR>',
-  'Description of my keymap'
-)
--- Returns the following table
-{
-  '<leader>f',
-  ':SomeCommand<CR>',
-  description = 'Description of my keymap',
-  mode = 'v',
-  opts = {
-    silent = true,
-    expr = true,
-    remap = false,
-  },
-}
+require('legendary.toolbox')
+  .table_from_vimscript(':vnoremap <silent> <expr> <leader>f :SomeCommand<CR>', 'Description of my keymap')
+  -- Returns the following table
+  ({
+    '<leader>f',
+    ':SomeCommand<CR>',
+    description = 'Description of my keymap',
+    mode = 'v',
+    opts = {
+      silent = true,
+      expr = true,
+      remap = false,
+    },
+  })
 ```

--- a/doc/API.md
+++ b/doc/API.md
@@ -106,10 +106,13 @@ require('legendary').find({
 
 ## Repeat Last Item
 
-You can repeat the previous item selected from `legendary.nvim`'s finder like so:
+You can repeat the previous item selected from `legendary.nvim`'s finder. By default, it only executes the item
+if the previous set of item filters used to select the item still returns `true`. You can ignore this with a
+parameter.
 
 ```lua
 require('legendary').repeat_previous()
+require('legendary').repeat_previous(--[[ ignore_filters: ]] true)
 ```
 
 ## Converting Keymaps From Vimscript

--- a/lua/legendary/api/cmds.lua
+++ b/lua/legendary/api/cmds.lua
@@ -63,10 +63,11 @@ end, {
   },
   {
     ':LegendaryRepeat',
-    function()
-      require('legendary').repeat_previous()
+    function(opts)
+      require('legendary').repeat_previous(opts.bang)
     end,
     description = "Repeat the last item executed via legendary.nvim's finder",
+    opts = { bang = true },
   },
   {
     ':LegendaryScratch',

--- a/lua/legendary/api/cmds.lua
+++ b/lua/legendary/api/cmds.lua
@@ -62,6 +62,13 @@ end, {
     },
   },
   {
+    ':LegendaryRepeat',
+    function()
+      require('legendary').repeat_previous()
+    end,
+    description = "Repeat the last item executed via legendary.nvim's finder",
+  },
+  {
     ':LegendaryScratch',
     function(args)
       local method = vim.tbl_get(args, 'fargs', 1)

--- a/lua/legendary/api/db/client.lua
+++ b/lua/legendary/api/db/client.lua
@@ -4,6 +4,8 @@
 local DbWrapper = require('legendary.api.db.wrapper')
 local Config = require('legendary.config')
 
+local shared_client = nil
+
 -- modifier used as a weight in the recency_score calculation:
 local recency_modifier = {
   [1] = { age = 240, value = 100 }, -- past 4 hours
@@ -81,6 +83,14 @@ end
 
 function M.sql_escape(str)
   return M.db_wrapper.sql_escape(str)
+end
+
+function M.get_client()
+  if not shared_client then
+    shared_client = M.init()
+  end
+
+  return shared_client
 end
 
 return M

--- a/lua/legendary/data/autocmd.lua
+++ b/lua/legendary/data/autocmd.lua
@@ -9,6 +9,7 @@ local Filters = require('legendary.data.filters')
 ---@field opts table
 ---@field description string
 ---@field group string|integer|nil
+---@field frecency_id fun(self):string
 ---@field class Autocmd
 local Autocmd = class('Autocmd')
 Autocmd:include(Filters) ---@diagnostic disable-line

--- a/lua/legendary/data/command.lua
+++ b/lua/legendary/data/command.lua
@@ -22,6 +22,7 @@ local Toolbox = require('legendary.toolbox')
 ---@field opts table
 ---@field unfinished boolean
 ---@field filters (function[])|nil
+---@field frecency_id fun(self):string
 ---@field builtin boolean
 ---@field class Command
 local Command = class('Command')

--- a/lua/legendary/data/function.lua
+++ b/lua/legendary/data/function.lua
@@ -7,6 +7,7 @@ local Filters = require('legendary.data.filters')
 ---@field description string
 ---@field opts table
 ---@field filters (function[])|nil
+---@field frecency_id fun(self):string
 ---@field class Function
 local Function = class('Function')
 Function:include(Filters) ---@diagnostic disable-line

--- a/lua/legendary/data/itemlist.lua
+++ b/lua/legendary/data/itemlist.lua
@@ -118,7 +118,7 @@ function ItemList:sort_inplace()
   if Config.sort.frecency ~= false then
     if require('legendary.api.db').is_supported() then
       -- inline require because this module requires sqlite and is a bit heavier
-      local DbClient = require('legendary.api.db.client').init()
+      local DbClient = require('legendary.api.db.client').get_client()
       -- if bootstrapping fails, bail
       if not require('legendary.api.db').is_supported() then
         Log.debug(

--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -26,6 +26,7 @@ local Filters = require('legendary.data.filters')
 ---@field opts table
 ---@field builtin boolean
 ---@field filters (function[])|nil
+---@field frecency_id fun(self):string
 ---@field class Keymap
 local Keymap = class('Keymap')
 Keymap:include(Filters) ---@diagnostic disable-line

--- a/lua/legendary/data/state.lua
+++ b/lua/legendary/data/state.lua
@@ -3,9 +3,11 @@ local ItemList = require('legendary.data.itemlist')
 ---@class LegendaryState
 ---@field items ItemList
 ---@field most_recent_item LegendaryItem|nil
+---@field most_recent_filters LegendaryItemFilter[]|nil
 local M = {}
 
 M.items = ItemList:create()
 M.most_recent_item = nil
+M.most_recent_filters = nil
 
 return M

--- a/lua/legendary/init.lua
+++ b/lua/legendary/init.lua
@@ -109,8 +109,11 @@ function M.setup(cfg)
   Log.trace('setup() parsed and applied all configuration.')
 end
 
-function M.repeat_previous()
-  require('legendary.api.executor').repeat_previous()
+---Repeat execution of the previously selected item. By default, only executes if the previously used filters
+---still return true.
+---@param ignore_filters boolean|nil whether to ignore the filters used when selecting the item, default false
+function M.repeat_previous(ignore_filters)
+  require('legendary.api.executor').repeat_previous(ignore_filters)
 end
 
 ---Find items using vim.ui.select()

--- a/lua/legendary/init.lua
+++ b/lua/legendary/init.lua
@@ -109,6 +109,10 @@ function M.setup(cfg)
   Log.trace('setup() parsed and applied all configuration.')
 end
 
+function M.repeat_previous()
+  require('legendary.api.executor').repeat_previous()
+end
+
 ---Find items using vim.ui.select()
 ---@param opts LegendaryFindOpts
 ---@overload fun()

--- a/lua/legendary/ui/init.lua
+++ b/lua/legendary/ui/init.lua
@@ -7,29 +7,6 @@ local Format = require('legendary.ui.format')
 local Executor = require('legendary.api.executor')
 local Log = require('legendary.log')
 
-local function update_item_frecency_score(item)
-  if Config.sort.frecency ~= false then
-    if require('legendary.api.db').is_supported() then
-      Log.trace('Updating scoring data for selected item.')
-      local DbClient = require('legendary.api.db.client').init()
-      -- if bootstrapping fails, bail
-      if not require('legendary.api.db').is_supported() then
-        Log.debug(
-          'Config.sort.frecency is enabled, but sqlite is not available or database could not be opened, '
-            .. 'frecency is automatically disabled.'
-        )
-        return
-      end
-      DbClient.update_item_score(item)
-    else
-      Log.debug(
-        'Config.sort.frecency is enabled, but sqlite is not available or database could not be opened, '
-          .. 'frecency is automatically disabled.'
-      )
-    end
-  end
-end
-
 ---@class LegendaryUi
 ---@field select fun(opts:LegendaryFindOpts)
 local M = {}
@@ -90,17 +67,12 @@ local function select_inner(opts, context, itemlist)
       return
     end
 
-    local ok, err = pcall(update_item_frecency_score, selected)
-    if not ok then
-      Log.error('Failed to update frecency score: %s', err)
-    end
-
-    State.most_recent_item = selected
     if Toolbox.is_itemgroup(selected) then
       return select_inner(opts, context, selected.items)
     end
 
     Log.trace('Preparing to execute selected item')
+    State.most_recent_item = selected
     Executor.exec_item(selected, context)
   end)
 end

--- a/lua/legendary/ui/init.lua
+++ b/lua/legendary/ui/init.lua
@@ -53,6 +53,8 @@ local function select_inner(opts, context, itemlist)
     return item_buf == nil or item_buf == local_context.buf
   end)
 
+  State.most_recent_filters = filters
+
   local items = itemlist:filter(filters, context)
   local padding = Format.compute_padding(items, opts.formatter or Config.default_item_formatter, context.mode)
 


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #384 

## How to Test

1. Run `legendary.nvim`'s finder UI and select a command
2. Call `:LegendaryRepeat` or `:lua require('legendary').repeat_previous()`
3. It should execute the last selected item again

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
