### PR TITLE
fix(executor): Preserve type of visual mode

### DIFF
--- a/lua/legendary/api/executor.lua
+++ b/lua/legendary/api/executor.lua
@@ -61,20 +61,10 @@ function M.restore_context(context, callback)
   if vim.startswith(context.mode, 'n') then
     vim.cmd('stopinsert')
   elseif Toolbox.is_visual_mode(context.mode) then
-    if true then  -- first solution
-      local vline, vcol, cline, ccol = unpack(context.marks)
-      local a, b
-      if cline < vline or ccol < vcol then  -- preserve side
-        a, b = '>', '<'
-      else
-        a, b = '<', '>'
-      end
-      vim.cmd('normal! `' .. a .. context.mode .. '`' .. b)
-    else  -- second solution
-      vim.cmd('normal! ' .. context.mode .. vim.api.nvim_replace_termcodes('<esc>', true, false, true))
-      Toolbox.set_marks(context.marks)
-      vim.cmd('normal! gv')
-    end
+    -- we can't just use `gv` since vim.ui.select aborts visual mode without any trace
+    vim.cmd(string.format('normal! %s%s', context.mode, vim.api.nvim_replace_termcodes('<esc>', true, false, true)))
+    Toolbox.set_marks(context.marks)
+    vim.cmd('normal! gv')
   elseif vim.startswith(context.mode, 'i') then
     vim.cmd('startinsert')
   else

--- a/lua/legendary/api/executor.lua
+++ b/lua/legendary/api/executor.lua
@@ -61,7 +61,20 @@ function M.restore_context(context, callback)
   if vim.startswith(context.mode, 'n') then
     vim.cmd('stopinsert')
   elseif Toolbox.is_visual_mode(context.mode) then
-    vim.cmd('normal! gv')
+    if true then  -- first solution
+      local vline, vcol, cline, ccol = unpack(context.marks)
+      local a, b
+      if cline < vline or ccol < vcol then  -- preserve side
+        a, b = '>', '<'
+      else
+        a, b = '<', '>'
+      end
+      vim.cmd('normal! `' .. a .. context.mode .. '`' .. b)
+    else  -- second solution
+      vim.cmd('normal! ' .. context.mode .. vim.api.nvim_replace_termcodes('<esc>', true, false, true))
+      Toolbox.set_marks(context.marks)
+      vim.cmd('normal! gv')
+    end
   elseif vim.startswith(context.mode, 'i') then
     vim.cmd('startinsert')
   else


### PR DESCRIPTION
Resolves: #375

## How to Test

1. select a range with `v`, `V` or `<c-v>`
2. escape
3. select a range with a different type and leave the cursor on either side
4. start legendary and choose a builtin motion (e.g. "Start of next word")
5. assert the type of visual mode and cursor side didn't change

## Testing for Regressions

I have tested the following:

- [ ] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [ ] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [ ] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [ ] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [ ] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
