### PR TITLE
feat(api): Allow config.keymaps/commands/autocmds/funcs/itemgroups to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,17 +314,18 @@ keymap, command, and `augroup`/`autocmd` tables, see [doc/table_structures/READM
 
 ```lua
 require('legendary').setup({
-  -- Initial keymaps to bind
+  -- Initial keymaps to bind, can also be a function that returns the list
   keymaps = {},
-  -- Initial commands to bind
+  -- Initial commands to bind, can also be a function that returns the list
   commands = {},
-  -- Initial augroups/autocmds to bind
+  -- Initial augroups/autocmds to bind, can also be a function that returns the list
   autocmds = {},
-  -- Initial functions to bind
+  -- Initial functions to bind, can also be a function that returns the list
   funcs = {},
   -- Initial item groups to bind,
   -- note that item groups can also
-  -- be under keymaps, commands, autocmds, or funcs
+  -- be under keymaps, commands, autocmds, or funcs;
+  -- can also be a function that returns the list
   itemgroups = {},
   -- default opts to merge with the `opts` table
   -- of each individual item

--- a/lua/legendary/config.lua
+++ b/lua/legendary/config.lua
@@ -202,6 +202,17 @@ local M = setmetatable({}, {
 function M.setup(cfg)
   config = vim.tbl_deep_extend('force', config, cfg or {})
   config = require('legendary.deprecate').check_config(config)
+
+  for _, key in ipairs({ 'keymaps', 'commands', 'autocmds', 'funcs', 'itemgroups' }) do
+    if type(config[key]) == 'function' then
+      local ok, result = pcall(config[key])
+      if ok then
+        config[key] = result
+      else
+        require('legendary.log').error('Failed to evaluate %s function: %s', key, result)
+      end
+    end
+  end
 end
 
 return M


### PR DESCRIPTION
… be functions which return the lists

<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #[issue number] <!-- If this PR fixes an open issue, please link it here -->

## How to Test

1. Please leave detailed testing instructions

## Testing for Regressions

I have tested the following:

- [ ] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [ ] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [ ] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [ ] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [ ] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
