### PR TITLE
fix(integrations): Fix lazy.nvim integration due to breaking change upstream

### DIFF
--- a/lua/legendary/integrations/lazy-nvim.lua
+++ b/lua/legendary/integrations/lazy-nvim.lua
@@ -13,8 +13,7 @@ function M.load_lazy_nvim_keys()
   local Handler = require('lazy.core.handler')
   for _, plugin in pairs(LazyNvimConfig.plugins) do
     local keys = Handler.handlers.keys:values(plugin)
-    for lhs, keymap in pairs(keys) do
-      print(vim.inspect({ lhs, keymap }))
+    for _, keymap in pairs(keys) do
       if keymap.desc and #keymap.desc > 0 then
         -- we don't need the implementation, since
         -- lazy.nvim will have already bound it. We


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #397 

## How to Test

1. With `config.lazy_nvim.auto_register`

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
