### PR TITLE
fix(docs): fix typo in lazy.nvim extension config

### DIFF
--- a/doc/EXTENSIONS.md
+++ b/doc/EXTENSIONS.md
@@ -70,7 +70,9 @@ into `legendary.nvim`.
 
 ```lua
 require('legendary').setup({
-  lazy_nvim = true,
+  extensions = {
+    lazy_nvim = true,
+  }
 })
 ```
 


### PR DESCRIPTION
Hi,

I just updated my config according to the recent change in the lazy.nvim extension to legendary.nvim. I figured that the configuration example of the lazy.nvim extension in the docs seems to have a typo, cf. the committed change to EXTENSIONS.md in this PR.
