### PR TITLE
fix(extension): Fix extension configuration for which-key.nvim extension

### DIFF
--- a/doc/WHICH_KEY.md
+++ b/doc/WHICH_KEY.md
@@ -32,7 +32,11 @@ require('legendary.util.which-key').bind_whichkey(
   your_which_key_opts,
   -- false if which-key.nvim handles binding them,
   -- set to true if you want legendary.nvim to handle binding
-  -- the mappings; if not passed, true by default
+  -- the mappings; if not passed, true by default.
   false,
+  -- true if you want to use item groups,
+  -- false if you want to add the items to the toplevel list
+  -- in legendary.nvim; defaults to true if omitted.
+  true,
 )
 ```

--- a/lua/legendary/extensions/which_key.lua
+++ b/lua/legendary/extensions/which_key.lua
@@ -20,15 +20,19 @@ return function(opts)
         opts.do_binding = false
       end
 
+      if opts.use_groups == nil then
+        opts.use_groups = true
+      end
+
       if #vim.tbl_keys(opts.mappings or {}) > 0 then
-        util.bind_whichkey(opts.mappings, opts.opts, opts.do_binding)
+        util.bind_whichkey(opts.mappings, opts.opts, opts.do_binding, opts.use_groups)
       end
     end
 
     local original = wk.register
     local listener = function(whichkey_tbls, whichkey_opts)
       Log.trace('Preparing to register items from which-key.nvim automatically')
-      util.bind_whichkey(whichkey_tbls, whichkey_opts, false)
+      util.bind_whichkey(whichkey_tbls, whichkey_opts, false, opts.use_groups)
       original(whichkey_tbls, whichkey_opts)
       Log.trace('Successfully registered items from which-key.nvim')
     end

--- a/lua/legendary/extensions/which_key.lua
+++ b/lua/legendary/extensions/which_key.lua
@@ -32,7 +32,7 @@ return function(opts)
     local original = wk.register
     local listener = function(whichkey_tbls, whichkey_opts)
       Log.trace('Preparing to register items from which-key.nvim automatically')
-      util.bind_whichkey(whichkey_tbls, whichkey_opts, false, opts.use_groups)
+      util.bind_whichkey(whichkey_tbls, whichkey_opts, opts.do_binding, opts.use_groups)
       original(whichkey_tbls, whichkey_opts)
       Log.trace('Successfully registered items from which-key.nvim')
     end

--- a/lua/legendary/util/which_key.lua
+++ b/lua/legendary/util/which_key.lua
@@ -10,7 +10,7 @@ local M = {}
 local function longest_matching_group(wk, wk_groups)
   local matching_group = {}
   for prefix, group_data in pairs(wk_groups) do
-    if vim.startswith(wk.prefix, prefix) and #prefix > #(matching_group[1] or '') then
+    if prefix == '' or vim.startswith(wk.prefix, prefix) and #prefix > #(matching_group[1] or '') then
       matching_group = { prefix, group_data }
     end
   end


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #404 

## How to Test

1. Which-key.nvim integration should work

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
