### PR TITLE
fix(extension): Fix lazy.nvim extension from breaking change upstream

### DIFF
--- a/lua/legendary/extensions/lazy_nvim.lua
+++ b/lua/legendary/extensions/lazy_nvim.lua
@@ -9,8 +9,9 @@ return function()
 
   local LazyNvimConfig = require('lazy.core.config')
   local Handler = require('lazy.core.handler')
+  local Plugin = require('lazy.core.plugin')
   for _, plugin in pairs(LazyNvimConfig.plugins) do
-    local keys = Handler.handlers.keys:values(plugin)
+    local keys = Handler.handlers.keys:_values(Plugin.values(plugin, 'keys', true), plugin)
     for _, keymap in pairs(keys) do
       if keymap.desc and #keymap.desc > 0 then
         -- we don't need the implementation, since


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #408 

## How to Test

1. Lazy.nvim extension should load keymaps from plugin specs

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
