### PR TITLE
feat(functions): Mode aware functions

### DIFF
--- a/doc/table_structures/FUNCTIONS.md
+++ b/doc/table_structures/FUNCTIONS.md
@@ -32,6 +32,27 @@ local functions = {
 }
 ```
 
+## Specifying mode
+
+By default, the funciton is shown and run in `*` (all) modes.
+You can use `mode` property to narrow function's scope, so it always run in specified mode:
+
+```lua
+local functions = {
+  {
+    mode = 'x', description = 'My function',
+    function() print('only runs in charwise-visual and selection mode!') end
+  },
+  {
+    description = 'Buffer: git: stage selected hunk'
+    mode = { 'x', 'V', 'v' },
+    function()
+      gitsigns.stage_hunk({ vim.fn.line('.'), vim.fn.line('v') })
+    end
+  }
+}
+```
+
 ## Options
 
 You can also pass options via the `opts` property:

--- a/lua/legendary/data/function.lua
+++ b/lua/legendary/data/function.lua
@@ -2,6 +2,21 @@ local class = require('legendary.vendor.middleclass')
 local util = require('legendary.util')
 local Filters = require('legendary.data.filters')
 
+---Check if modes is an array of strings or itself a string
+---@param modes table
+---@return boolean
+local is_list_of_strings_or_string = function(modes)
+  if modes == nil or type(modes) == 'string' then
+    return true
+  end
+  for _, mode in ipairs(modes) do
+    if type(mode) ~= 'string' then
+      return false
+    end
+  end
+  return true
+end
+
 ---@class Function
 ---@field implementation function
 ---@field description string
@@ -15,6 +30,11 @@ Function:include(Filters) ---@diagnostic disable-line
 function Function:parse(tbl) -- luacheck: no unused
   vim.validate({
     ['1'] = { tbl[1], { 'function' } },
+    mode = {
+      tbl.mode,
+      is_list_of_strings_or_string,
+      'item.mode should contain only strings of modes: n, i, v etc.',
+    },
     description = { util.get_desc(tbl), { 'string' } },
     opts = { tbl.opts, { 'table' }, true },
   })

--- a/lua/legendary/data/function.lua
+++ b/lua/legendary/data/function.lua
@@ -87,4 +87,19 @@ function Function:frecency_id()
   return string.format('<function> %s', self.description)
 end
 
+--- Intended to be used by UI filters
+function Function:modeSwitched()
+  return self._mode_switched
+end
+
+function Function:modes()
+  if self:modeSwitched() then
+    return self.mode_mappings
+  else
+    -- Just use all modes for UI filtering
+    -- it's half-assed because UI filtering is ugly ¯\_(ツ)_/¯
+    return { 'n', 'V', 'v', 'x', 's', 'o', '' }
+  end
+end
+
 return Function

--- a/lua/legendary/filters.lua
+++ b/lua/legendary/filters.lua
@@ -10,8 +10,9 @@ local M = {}
 ---@return LegendaryItemFilter
 function M.mode(mode)
   return function(item)
-    -- include everything that isn't a keymap since they aren't tied to a mode
-    if not Toolbox.is_keymap(item) then
+    -- allow only keymaps and functions
+    -- TODO: include commands
+    if not (Toolbox.is_keymap(item) or Toolbox.is_function(item)) then
       return true
     end
 
@@ -26,9 +27,9 @@ function M.mode(mode)
     end
 
     -- filter where any filter_modes match any item:modes()
-    return #vim.tbl_filter(function(keymap_mode)
+    return #vim.tbl_filter(function(item_mode)
       return #vim.tbl_filter(function(filter_mode)
-        return filter_mode == keymap_mode
+        return filter_mode == item_mode
       end, filter_modes) > 0
     end, item:modes()) > 0
   end

--- a/lua/legendary/ui/format.lua
+++ b/lua/legendary/ui/format.lua
@@ -38,11 +38,15 @@ function M.default_format(item)
       item.description,
     }
   elseif Toolbox.is_function(item) then
+    -- stylua: ignore start
     return {
-      Config.icons.fn,
+      item--[[@as keymap ]]:modeSwitched()
+        and table.concat(item--[[@as Keymap]]:modes(), ', ')
+        or Config.icons.fn,
       '<function>',
       item.description,
     }
+    -- stylua: ignore end
   elseif Toolbox.is_itemgroup(item) then
     return {
       item.icon or Config.icons.itemgroup,


### PR DESCRIPTION
https://github.com/mrjones2014/legendary.nvim/assets/8136158/83c5a565-228e-46fd-9059-fcc43d1758b6

**Summary:**
- feat(functions): populate `mode_mappings`
- feat(functions): add methods for UI display filtering
- feat(functions): allow filtering by functions
- feat(functions): display multi-mode functions
- docs(functions): describe new mode=field

> [!NOTE]
> I request to squash-rebase

## How to Test

New `funcs = { ... mode = 'n' }` field for functions - its type should be either `string` or `table<string>`; that's it

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly

