### PR TITLE
refactor(commands): move util function to toolbox

### DIFF
--- a/lua/legendary/data/command.lua
+++ b/lua/legendary/data/command.lua
@@ -40,26 +40,6 @@ local function exec(impl, args)
   end
 end
 
-local function parse_modemap(map)
-  return function(args)
-    local mode = vim.fn.mode()
-    local impl = map[mode]
-    if not impl then
-      if Toolbox.is_visual_mode(mode) then
-        impl = impl or map.v or map.x or map.s
-      elseif mode == 'i' then
-        impl = impl or map.l
-      elseif mode == 'c' then
-        impl = impl or map.l
-      end
-    end
-
-    if impl then
-      exec(impl, args)
-    end
-  end
-end
-
 ---Parse a new command table
 ---@param tbl table
 ---@param builtin boolean Whether the item is a builtin, defaults to false
@@ -98,7 +78,7 @@ function Command:parse(tbl, builtin) -- luacheck: no unused
       l = { tbl[2].i, { 'string', 'function' }, true },
     })
 
-    instance.implementation = parse_modemap(instance.implementation)
+    instance.implementation = Toolbox.map_cur_mode_into_impl(instance.implementation, exec)
   end
   instance:parse_filters(tbl.filters)
 

--- a/lua/legendary/toolbox.lua
+++ b/lua/legendary/toolbox.lua
@@ -185,4 +185,29 @@ function M.table_from_vimscript(vimscript_str, description)
   return input
 end
 
+--- Takes instance specific mode implementation and executes callback
+--- with a instance implementation per current nvim mode
+--- @param instanceModeMap table
+--- @param callback function
+--- @return function
+function M.map_cur_mode_into_impl(instanceModeMap, callback)
+  return function(args)
+    local mode = vim.fn.mode()
+    local impl = instanceModeMap[mode]
+    if not impl then
+      if Toolbox.is_visual_mode(mode) then
+        impl = impl or instanceModeMap.v or instanceModeMap.x or instanceModeMap.s
+      elseif mode == 'i' then
+        impl = impl or instanceModeMap.l
+      elseif mode == 'c' then
+        impl = impl or instanceModeMap.l
+      end
+    end
+
+    if impl then
+      callback(impl, args)
+    end
+  end
+end
+
 return M


### PR DESCRIPTION
I actually wanted to include this patch into #415 PR, but decided to go separately. 

## How to Test

N/A

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
