### PR TITLE
fix(extension): Make which_key extension respect auto_register config

### DIFF
--- a/lua/legendary/extensions/which_key.lua
+++ b/lua/legendary/extensions/which_key.lua
@@ -29,14 +29,16 @@ return function(opts)
       end
     end
 
-    local original = wk.register
-    local listener = function(whichkey_tbls, whichkey_opts)
-      Log.trace('Preparing to register items from which-key.nvim automatically')
-      util.bind_whichkey(whichkey_tbls, whichkey_opts, opts.do_binding, opts.use_groups)
-      original(whichkey_tbls, whichkey_opts)
-      Log.trace('Successfully registered items from which-key.nvim')
+    if opts.auto_register then
+      local original = wk.register
+      local listener = function(whichkey_tbls, whichkey_opts)
+        Log.trace('Preparing to register items from which-key.nvim automatically')
+        util.bind_whichkey(whichkey_tbls, whichkey_opts, opts.do_binding, opts.use_groups)
+        original(whichkey_tbls, whichkey_opts)
+        Log.trace('Successfully registered items from which-key.nvim')
+      end
+      wk.register = listener
     end
-    wk.register = listener
   else
     Log.warn(
       'which-key.nvim not available. If you are lazy-loading, be sure that which-key.nvim is added to runtime path '


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #417 

## How to Test

1. Setting `extensions.which_key.auto_register = false` should be respected

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
