### PR TITLE
fix(scratchpad): Treat boolean false as a valid return value

### DIFF
--- a/lua/legendary/ui/scratchpad.lua
+++ b/lua/legendary/ui/scratchpad.lua
@@ -75,13 +75,13 @@ end
 
 local function results_win(result, err)
   local lines = nil
-  if err then
+  if err ~= nil then
     lines = err
-  elseif result then
+  elseif result ~= nil then
     lines = result
   end
 
-  if not lines then
+  if lines == nil then
     Log.warn('[legendary.nvim] No return value from Lua evaluation.')
     return
   end


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #420 

## How to Test

1. Type `return false` in scratchpad
2. Eval lua
3. Should show returned boolean instead of saying "no return value"

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
