### PR TITLE
fix(api): Apply `itemgroup` filter correctly

### DIFF
--- a/lua/legendary/ui/init.lua
+++ b/lua/legendary/ui/init.lua
@@ -32,7 +32,7 @@ local function select_inner(opts, context, itemlist)
 
   if itemlist then
     Log.trace('Launching select UI')
-  else
+  elseif opts.itemgroup then
     Log.trace('Relaunching select UI for an item group')
     -- if no itemlist passed, try to use itemgroup
     -- if an item group id is specified, use that
@@ -42,6 +42,8 @@ local function select_inner(opts, context, itemlist)
     else
       Log.error('Expected itemlist, got %s.\n    %s', type(itemlist), vim.inspect(itemlist))
     end
+  else
+    itemlist = State.items
   end
 
   local prompt = opts.select_prompt or Config.select_prompt
@@ -105,7 +107,7 @@ end
 function M.select(opts)
   vim.cmd('doautocmd User LegendaryUiPre')
   local context = Executor.build_context()
-  select_inner(opts, context, State.items)
+  select_inner(opts, context)
 end
 
 return M


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #435 

## How to Test

1. Have an item group
2. Trigger the API via `require('legendary').find({ itemgroup = "my group" })`
3. It should start the finder with items from the group

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
