### PR TITLE
fix(api): Fix toolbox functions to work if items are deepcopied

### DIFF
--- a/lua/legendary/toolbox.lua
+++ b/lua/legendary/toolbox.lua
@@ -84,32 +84,36 @@ function M.vsplit_then(fn)
   end
 end
 
+local function check_class(item, class)
+  return vim.tbl_get(item or {}, 'class', 'name') == class
+end
+
 ---Check if an item is a Keymap
 ---@param keymap LegendaryItem
 ---@return boolean
 function M.is_keymap(keymap)
-  return keymap.class.name == 'Keymap'
+  return check_class(keymap, 'Keymap')
 end
 
 ---Check if an item is a Command
 ---@param cmd LegendaryItem
 ---@return boolean
 function M.is_command(cmd)
-  return cmd.class.name == 'Command'
+  return check_class(cmd, 'Command')
 end
 
 ---Check if an item is an Augroup
 ---@param au LegendaryItem
 ---@return boolean
 function M.is_augroup(au)
-  return au.class.name == 'Augroup'
+  return check_class(au, 'Augroup')
 end
 
 ---Check if an item is an Autocmd
 ---@param autocmd LegendaryItem
 ---@return boolean
 function M.is_autocmd(autocmd)
-  return autocmd.class.name == 'Autocmd'
+  return check_class(autocmd, 'Autocmd')
 end
 
 ---Check if an item is an Augroup or Autocmd
@@ -120,14 +124,14 @@ function M.is_augroup_or_autocmd(au_or_autocmd)
 end
 
 function M.is_itemgroup(group)
-  return group.class.name == 'ItemGroup'
+  return check_class(group, 'ItemGroup')
 end
 
 ---Check if an item is a Function
 ---@param func LegendaryItem
 ---@return boolean
 function M.is_function(func)
-  return func.class.name == 'Function'
+  return check_class(func, 'Function')
 end
 
 ---Check if the given mode string indicates a visual mode or a sub-mode of visual mode.

--- a/lua/legendary/toolbox.lua
+++ b/lua/legendary/toolbox.lua
@@ -88,54 +88,46 @@ end
 ---@param keymap LegendaryItem
 ---@return boolean
 function M.is_keymap(keymap)
-  -- inline require to avoid circular dependency
-  return keymap.class == require('legendary.data.keymap')
+  return keymap.class.name == 'Keymap'
 end
 
 ---Check if an item is a Command
 ---@param cmd LegendaryItem
 ---@return boolean
 function M.is_command(cmd)
-  -- inline require to avoid circular dependency
-  return cmd.class == require('legendary.data.command')
+  return cmd.class.name == 'Command'
 end
 
 ---Check if an item is an Augroup
 ---@param au LegendaryItem
 ---@return boolean
 function M.is_augroup(au)
-  -- inline require to avoid circular dependency
-  return au.class == require('legendary.data.augroup')
+  return au.class.name == 'Augroup'
 end
 
 ---Check if an item is an Autocmd
 ---@param autocmd LegendaryItem
 ---@return boolean
 function M.is_autocmd(autocmd)
-  -- inline require to avoid circular dependency
-  return autocmd.class == require('legendary.data.autocmd')
+  return autocmd.class.name == 'Autocmd'
 end
 
 ---Check if an item is an Augroup or Autocmd
 ---@param au_or_autocmd LegendaryItem
 ---@return boolean
 function M.is_augroup_or_autocmd(au_or_autocmd)
-  -- inline require to avoid circular dependency
-  return au_or_autocmd.class == require('legendary.data.augroup')
-    or au_or_autocmd.class == require('legendary.data.autocmd')
+  return M.is_autocmd(au_or_autocmd) or M.is_augroup(au_or_autocmd)
 end
 
 function M.is_itemgroup(group)
-  -- inline require to avoid circular dependency
-  return group.class == require('legendary.data.itemgroup')
+  return group.class.name == 'ItemGroup'
 end
 
 ---Check if an item is a Function
 ---@param func LegendaryItem
 ---@return boolean
 function M.is_function(func)
-  -- inline require to avoid circular dependency
-  return func.class == require('legendary.data.function')
+  return func.class.name == 'Function'
 end
 
 ---Check if the given mode string indicates a visual mode or a sub-mode of visual mode.


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #437 

## How to Test

Follow reproduction steps described in issue.

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
