### PR TITLE
fix(ui): Fix validation for `select_prompt` option

### DIFF
--- a/lua/legendary/ui/init.lua
+++ b/lua/legendary/ui/init.lua
@@ -27,7 +27,7 @@ local function select_inner(opts, context, itemlist)
 
   vim.validate({
     itemgroup = { opts.itemgroup, 'string', true },
-    select_prompt = { opts.select_prompt, 'function', true },
+    select_prompt = { opts.select_prompt, { 'string', 'function' }, true },
   })
 
   if itemlist then


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #440 

## How to Test

1. `:lua require('legendary').find({ select_prompt = 'Custom prompt' })`

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
