### PR TITLE
refactor: use `vim.islist()` instead of deprecated `vim.tbl_islist()`

### DIFF
--- a/lua/legendary/data/keymap.lua
+++ b/lua/legendary/data/keymap.lua
@@ -109,7 +109,8 @@ end
 ---Bind the keymap in Neovim
 ---@return Keymap
 function Keymap:apply()
-  if vim.tbl_islist(self.mode_mappings) then
+  local islist = vim.islist or vim.tbl_islist
+  if islist(self.mode_mappings) then
     -- description-only keymap
     return self
   end
@@ -133,7 +134,8 @@ function Keymap:frecency_id()
 end
 
 function Keymap:modes()
-  if vim.tbl_islist(self.mode_mappings) then
+  local islist = vim.islist or vim.tbl_islist
+  if islist(self.mode_mappings) then
     return self.mode_mappings
   end
 

--- a/lua/legendary/init.lua
+++ b/lua/legendary/init.lua
@@ -35,7 +35,8 @@ local function build_parser_func(parser)
       return
     end
 
-    if not vim.tbl_islist(items) then
+    local islist = vim.islist or vim.tbl_islist
+    if not islist(items) then
       error(string.format('Expected list, got ', type(items)))
       return
     end
@@ -159,7 +160,8 @@ end
 ---Bind a *list of* autocmds and/or augroups
 ---@param aus table
 function M.autocmds(aus)
-  if not vim.tbl_islist(aus) then
+  local islist = vim.islist or vim.tbl_islist
+  if not islist(aus) then
     Log.error('Expected list, got %s.\n    %s', type(aus), vim.inspect(aus))
     return
   end


### PR DESCRIPTION
`vim.tbl_islist()` is deprecated and will be removed in Neovim 0.12. This causes depcrecation warnings on 0.11.
ref: https://github.com/neovim/neovim/blob/512d228111bccf3e52613c798edc7f803c1de13f/runtime/doc/deprecated.txt#L68

<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
