### PR TITLE
fix(frecency)!: Use byte strings for DB IDs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,5 +42,10 @@ jobs:
       with:
         repository: Olivine-Labs/luassert
         path: vendor/luassert
+    - name: Checkout sqlite.lua
+      uses: actions/checkout@v3
+      with:
+        repository: kkharji/sqlite.lua
+        path: vendor/sqlite
     - name: Run Unit Tests
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,13 @@ ensure-test-deps:
 	@mkdir -p vendor
 	@if test ! -d ./vendor/plenary.nvim; then git clone git@github.com:nvim-lua/plenary.nvim.git ./vendor/plenary.nvim/; fi
 	@if test ! -d ./vendor/luassert; then git clone git@github.com:Olivine-Labs/luassert.git ./vendor/luassert/; fi
+	@if test ! -d ./vendor/sqlite; then git clone git@github.com:kkharji/sqlite.lua.git ./vendor/sqlite/; fi
 
 .PHONY: update-test-deps
 update-test-deps: ensure-test-deps
 	@cd ./vendor/plenary.nvim/ && git pull && cd ..
 	@cd ./vendor/luassert/ && git pull && cd ..
+	@cd ./vendor/sqlite/ && git pull && cd ..
 
 .PHONY: ensure-doc-deps
 ensure-doc-deps:

--- a/lua/legendary/api/db/client.lua
+++ b/lua/legendary/api/db/client.lua
@@ -81,8 +81,8 @@ function M.update_item_score(item)
   M.db_wrapper:update(item)
 end
 
-function M.sql_escape(str)
-  return M.db_wrapper.sql_escape(str)
+function M.to_bytes(str)
+  return M.db_wrapper.to_bytes(str)
 end
 
 function M.get_client()

--- a/lua/legendary/api/db/wrapper.lua
+++ b/lua/legendary/api/db/wrapper.lua
@@ -155,14 +155,18 @@ local function row_id(row)
   return (not vim.tbl_isempty(row)) and row[1].id or nil
 end
 
-function M.sql_escape(str)
-  return string.format("'%s'", string.gsub(str, "'", "\\'"))
+function M.to_bytes(str)
+  local result = ''
+  for c in str:gmatch('.') do
+    result = result .. string.byte(c)
+  end
+  return result
 end
 
 ---Update the stored data for an item
 ---@param item LegendaryItem
 function M:update(item)
-  local item_id = M.sql_escape(item:frecency_id())
+  local item_id = M.to_bytes(item:frecency_id())
   Log.trace('Updating item with ID "%s"', item_id)
   local entry_id = row_id(self:transaction(self.queries.item_get_entries, { where = { item_id = item_id } }))
   if not entry_id then

--- a/lua/legendary/data/itemlist.lua
+++ b/lua/legendary/data/itemlist.lua
@@ -164,8 +164,8 @@ function ItemList:sort_inplace(opts)
         ---@param item1 LegendaryItem
         ---@param item2 LegendaryItem
         function(item1, item2)
-          local item1_id = DbClient.sql_escape(item1:frecency_id())
-          local item2_id = DbClient.sql_escape(item2:frecency_id())
+          local item1_id = DbClient.to_bytes(item1:frecency_id())
+          local item2_id = DbClient.to_bytes(item2:frecency_id())
           local item1_score = frecency_scores[item1_id] or 0
           local item2_score = frecency_scores[item2_id] or 0
           return item1_score > item2_score

--- a/tests/legendary/to_bytes_spec.lua
+++ b/tests/legendary/to_bytes_spec.lua
@@ -1,0 +1,16 @@
+local assert = require('luassert')
+local wrapper = require('legendary.api.db.wrapper')
+
+describe('to_bytes function', function()
+  local test_data = {
+    ['test string'] = '11610111511632115116114105110103',
+    ['with icons 󰊢'] = '119105116104321059911111011532243176138162238158168238153135',
+    ['with quote chars \'"'] = '11910511610432113117111116101329910497114115323934',
+    ['with emoji 🦀'] = '1191051161043210110911110610532240159166128',
+  }
+  for input, output in pairs(test_data) do
+    it(string.format('for input `%s`, output should be "%s"', input, output), function()
+      assert.are.same(wrapper.to_bytes(input), output)
+    end)
+  end
+end)

--- a/tests/testrc.lua
+++ b/tests/testrc.lua
@@ -2,6 +2,7 @@ vim.cmd([[
   set rtp+=.
   set rtp+=vendor/plenary.nvim
   set rtp+=vendor/luassert
+  set rtp+=vendor/sqlite
   runtime plugin/plenary.vim
 ]])
 require('plenary.busted')


### PR DESCRIPTION
<!-- If you have not contributed before, **please read CONTRIBUTING.md (https://github.com/mrjones2014/legendary.nvim/blob/master/CONTRIBUTING.md)!** -->

Resolves: #472 

## How to Test

1. Note that existing frecency data will unfortunately be invalid because the ID algorithm changed.
2. Try an item with a `'`' and/or `"` in the description e.g.
```lua
return {
    'kylechui/nvim-surround',
    version = "*", -- Use for stability; omit to use `main` branch for the latest features
    keys = {
        { "<leader>'", '<Cmd>normal cs"\'<CR>', desc = 'Change surrounding " to \'' },
        { '<leader>"', '<Cmd>normal cs\'"<CR>', desc = 'Change surrounding \' to "' },
    },
    config = function ()
        require('nvim-surround').setup({ })
    end
}
```
with `lazy_nvim` extension and the frecency sorting enabled.

## Testing for Regressions

I have tested the following:

- [x] Triggering keymaps from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating keymaps via `legendary.nvim`, then triggering via the keymap in all modes (normal, insert, visual)
- [x] Triggering commands from `legendary.nvim` in all modes (normal, insert, visual)
- [x] Creating commands via `legendary.nvim`, then running the command manually from the command line
- [x] `augroup`/`autocmd`s created through `legendary.nvim` work correctly
